### PR TITLE
Remove duplicate memory barrier

### DIFF
--- a/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
+++ b/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
@@ -42,10 +42,8 @@ namespace Adaptive.Aeron.LogBuffer
             var streamAndTermIds = _streamId | ((long)termId << 32);
 
             termBuffer.PutLongOrdered(offset + HeaderFlyweight.FRAME_LENGTH_FIELD_OFFSET, lengthVersionFlagsType);
-            // PutLongOrdered use Volatile.Write that already generates an implicit memory barrier
-            // no need for Thread.MemoryBarrier();
 
-            termBuffer.PutLong(offset + DataHeaderFlyweight.TERM_OFFSET_FIELD_OFFSET, termOffsetSessionId);
+            termBuffer.PutLongOrdered(offset + DataHeaderFlyweight.TERM_OFFSET_FIELD_OFFSET, termOffsetSessionId);
             termBuffer.PutLong(offset + DataHeaderFlyweight.STREAM_ID_FIELD_OFFSET, streamAndTermIds);
         }
     }

--- a/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
+++ b/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
@@ -41,9 +41,9 @@ namespace Adaptive.Aeron.LogBuffer
             var termOffsetSessionId = _sessionId | (uint)offset;
             var streamAndTermIds = _streamId | ((long)termId << 32);
 
-            //TODO why not just putlongvolatile?
             termBuffer.PutLongOrdered(offset + HeaderFlyweight.FRAME_LENGTH_FIELD_OFFSET, lengthVersionFlagsType);
-            Thread.MemoryBarrier();
+            // PutLongOrdered use Volatile.Write that already generates an implicit memory barrier
+            // no need for Thread.MemoryBarrier();
 
             termBuffer.PutLong(offset + DataHeaderFlyweight.TERM_OFFSET_FIELD_OFFSET, termOffsetSessionId);
             termBuffer.PutLong(offset + DataHeaderFlyweight.STREAM_ID_FIELD_OFFSET, streamAndTermIds);


### PR DESCRIPTION
PutLongOrdered uses Volatile.Write that already generates an implicit memory barrier, no need for Thread.MemoryBarrier() after it. http://stackoverflow.com/a/6932271/801189

Note that we keep one fence as opposed to my initial comment in #29 to remove both. @mjpt777 then explained that "The fence ordering is important to detection of dead clients that have written a partial message." But performance gain is still around 15-20%. @JPWatson already had a comment on that line about that and he was definitely right, this should be removed.