### PR TITLE
Optimize memory copy

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
@@ -576,8 +576,8 @@ namespace Adaptive.Agrona.Concurrent
             BoundsCheck0(index, length);
             BufferUtil.BoundsCheck(dst, offset, length);
 
-            void* source = _pBuffer + index;
-            fixed (void* destination = &dst[offset])
+            byte* source = _pBuffer + index;
+            fixed (byte* destination = &dst[offset])
             {
                 ByteUtil.MemoryCopy(destination, source, (uint) length);
             }
@@ -601,8 +601,8 @@ namespace Adaptive.Agrona.Concurrent
             BoundsCheck0(index, length);
             BufferUtil.BoundsCheck(src, offset, length);
 
-            void* destination = _pBuffer + index;
-            fixed (void* source = &src[offset])
+            byte* destination = _pBuffer + index;
+            fixed (byte* source = &src[offset])
             {
                 ByteUtil.MemoryCopy(destination, source, (uint) length);
             }
@@ -614,8 +614,8 @@ namespace Adaptive.Agrona.Concurrent
             BoundsCheck0(index, length);
             srcBuffer.BoundsCheck(srcIndex, length);
 
-            void* destination = _pBuffer + index;
-            void* source = (byte*) srcBuffer.BufferPointer.ToPointer() + srcIndex;
+            byte* destination = _pBuffer + index;
+            byte* source = (byte*) srcBuffer.BufferPointer.ToPointer() + srcIndex;
             ByteUtil.MemoryCopy(destination, source, (uint) length);
         }
 

--- a/src/Adaptive.Agrona/Util/ByteUtil.cs
+++ b/src/Adaptive.Agrona/Util/ByteUtil.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Altar;
 namespace Adaptive.Agrona.Util {
 
     /// <summary>

--- a/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Adaptive.Aeron.Samples.IpcThroughput.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Adaptive.Aeron.Samples.IpcThroughput.csproj
@@ -31,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This is not as straightforward as the previous two, need confirmation on different machines and review. Probably these several lines could be written smarter to minimize CPU insructions and jumps.

On my two machines a c.5% difference is visible.

A delegate is never a candidate for inlining by JIT, this is probably the main factor for speedup (PerfView confirms that the manual copy is inlined). However, this [post](http://frankniemeyer.blogspot.ru/2014/07/methods-for-reading-structured-binary.html) shows that pointer copy is even faster than cpblk for smaller sizes.

I played with different combinations. Just [32,1] is the fastest, but I left [32,8,1] because the benchmark is not representative and performance is very close to just [32, 1]. Adding 64 and 4 steps slows down the benchmark slightly.

