### PR TITLE
Cache  in a local variable the delegates passed to Poll method.

### DIFF
--- a/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/BufferClaimIpcThroughput.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/BufferClaimIpcThroughput.cs
@@ -154,10 +154,11 @@ namespace Adaptive.Aeron.Samples.BufferClaimIpcThroughput
 
                 long failedPolls = 0;
                 long successfulPolls = 0;
+                FragmentHandler onFragment = OnFragment;
 
                 while (Running.Get())
                 {
-                    var fragmentsRead = image.Poll(OnFragment, MessageCountLimit);
+                    var fragmentsRead = image.Poll(onFragment, MessageCountLimit);
                     if (0 == fragmentsRead)
                     {
                         ++failedPolls;

--- a/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/IpcThroughput.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/IpcThroughput.cs
@@ -151,11 +151,11 @@ namespace Adaptive.Aeron.Samples.IpcThroughput
 
                 long failedPolls = 0;
                 long successfulPolls = 0;
-
-
+                FragmentHandler onFragment = OnFragment;
+                
                 while (Running.Get())
                 {
-                    var fragmentsRead = image.Poll(OnFragment, MessageCountLimit);
+                    var fragmentsRead = image.Poll(onFragment, MessageCountLimit);
                     if (0 == fragmentsRead)
                     {
                         ++failedPolls;


### PR DESCRIPTION
Method groups to delegate conversation currently allocates a new instance of the delegate.
It is the cause of all allocations in IpcThroughput sample.
