### PR TITLE
Use ThrowHelper to ensure inlining

### DIFF
--- a/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
+++ b/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="ImageTest.cs" />
     <Compile Include="LogBuffer\TermAppenderTest.cs" />
     <Compile Include="LogBuffer\TermBlockScannerTest.cs" />
+    <Compile Include="LogBuffer\TermGapFillerTests.cs" />
     <Compile Include="LogBuffer\TermReaderTest.cs" />
     <Compile Include="LogBuffer\TermRebuilderTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
+++ b/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
@@ -48,13 +48,11 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.0.0-rc2\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=3.4.2.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.4.2\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
+++ b/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="SubscriptionTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Adaptive.Aeron.Tests.licenseheader" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.licenseheader
+++ b/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Adaptive.Aeron.Tests/BufferBuilderTests.cs
+++ b/src/Adaptive.Aeron.Tests/BufferBuilderTests.cs
@@ -50,6 +50,18 @@ namespace Adaptive.Aeron.Tests
         }
 
         [Test]
+        public void ShouldGrowToMultipleOfInitialCapaity()
+        {
+            int srcCapacity = BufferBuilder.INITIAL_CAPACITY * 5;
+            UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[srcCapacity]);
+
+            _bufferBuilder.Append(srcBuffer, 0, srcBuffer.Capacity);
+
+            Assert.That(_bufferBuilder.Limit(), Is.EqualTo(srcCapacity));
+            Assert.That(_bufferBuilder.Capacity, Is.GreaterThanOrEqualTo(srcCapacity));
+        }
+
+        [Test]
         public void ShouldAppendThenReset()
         {
             UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[BufferBuilder.INITIAL_CAPACITY]);
@@ -134,7 +146,7 @@ namespace Adaptive.Aeron.Tests
             bufferBuilder.Buffer().GetBytes(0, temp, 0, buffer.Length);
 
             Assert.That(bufferBuilder.Limit(), Is.EqualTo(buffer.Length));
-            Assert.That(bufferBuilder.Capacity(), Is.EqualTo(bufferLength * 2));
+            Assert.That(bufferBuilder.Capacity(), Is.GreaterThan(bufferLength));
             Assert.That(temp, Is.EqualTo(buffer));
         }
 
@@ -157,7 +169,7 @@ namespace Adaptive.Aeron.Tests
             bufferBuilder.Buffer().GetBytes(0, temp, 0, secondLength + firstLength);
 
             Assert.That(bufferBuilder.Limit(), Is.EqualTo(firstLength + secondLength));
-            Assert.That(bufferBuilder.Capacity(), Is.EqualTo(bufferLength));
+            Assert.That(bufferBuilder.Capacity(), Is.GreaterThanOrEqualTo(firstLength + secondLength));
             Assert.That(temp, Is.EqualTo(buffer));
         }
 

--- a/src/Adaptive.Aeron.Tests/BufferBuilderTests.cs
+++ b/src/Adaptive.Aeron.Tests/BufferBuilderTests.cs
@@ -1,4 +1,20 @@
-﻿using System.Text;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
 using Adaptive.Agrona.Concurrent;
 using NUnit.Framework;
 

--- a/src/Adaptive.Aeron.Tests/ClientConductorTest.cs
+++ b/src/Adaptive.Aeron.Tests/ClientConductorTest.cs
@@ -443,7 +443,7 @@ namespace Adaptive.Aeron.Tests
 
             Conductor.OnAvailableImage(STREAM_ID_1, SESSION_ID_1, SubscriberPositionMap, SESSION_ID_1 + "-log", SOURCE_INFO, CORRELATION_ID);
 
-            Assert.False(subscription.HasNoImages);
+            Assert.False(subscription.HasNoImages());
 
             A.CallTo(() => MockAvailableImageHandler(A<Image>._)).MustHaveHappened();
 
@@ -451,7 +451,7 @@ namespace Adaptive.Aeron.Tests
 
             A.CallTo(() => MockUnavailableImageHandler(A<Image>._)).MustHaveHappened();
 
-            Assert.True(subscription.HasNoImages);
+            Assert.True(subscription.HasNoImages());
         }
 
         [Test]

--- a/src/Adaptive.Aeron.Tests/ClientConductorTest.cs
+++ b/src/Adaptive.Aeron.Tests/ClientConductorTest.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Adaptive.Aeron.Command;

--- a/src/Adaptive.Aeron.Tests/DriverProxyTests.cs
+++ b/src/Adaptive.Aeron.Tests/DriverProxyTests.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Aeron.Command;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Concurrent.RingBuffer;

--- a/src/Adaptive.Aeron.Tests/FlyweightTests.cs
+++ b/src/Adaptive.Aeron.Tests/FlyweightTests.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.Protocol;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona.Concurrent;
 using NUnit.Framework;
 

--- a/src/Adaptive.Aeron.Tests/FragmentAssemblerTest.cs
+++ b/src/Adaptive.Aeron.Tests/FragmentAssemblerTest.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron.Tests/ImageTest.cs
+++ b/src/Adaptive.Aeron.Tests/ImageTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermAppenderTest.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermAppenderTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermBlockScannerTest.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermBlockScannerTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 using FakeItEasy;

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.LogBuffer.io.aeron.logbuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
@@ -1,0 +1,122 @@
+﻿using Adaptive.Aeron.LogBuffer;
+using Adaptive.Aeron.LogBuffer.io.aeron.logbuffer;
+using Adaptive.Aeron.Protocol;
+using Adaptive.Agrona.Concurrent;
+using NUnit.Framework;
+
+namespace Adaptive.Aeron.Tests.LogBuffer
+{
+    [TestFixture]
+    public class TermGapFillerTest
+    {
+        private bool InstanceFieldsInitialized;
+        private const int INITIAL_TERM_ID = 11;
+        private const int TERM_ID = 22;
+        private const int SESSION_ID = 333;
+        private const int STREAM_ID = 7;
+
+        private UnsafeBuffer metaDataBuffer;
+        private UnsafeBuffer termBuffer;
+        private DataHeaderFlyweight dataFlyweight;
+
+        [SetUp]
+        public virtual void Setup()
+        {
+            metaDataBuffer = new UnsafeBuffer(new byte[LogBufferDescriptor.LOG_META_DATA_LENGTH]);
+            termBuffer = new UnsafeBuffer(new byte[LogBufferDescriptor.TERM_MIN_LENGTH]);
+            dataFlyweight = new DataHeaderFlyweight(termBuffer);
+            LogBufferDescriptor.InitialTermId(metaDataBuffer, INITIAL_TERM_ID);
+            LogBufferDescriptor.StoreDefaultFrameHeader(metaDataBuffer, DataHeaderFlyweight.CreateDefaultHeader(SESSION_ID, STREAM_ID, INITIAL_TERM_ID));
+        }
+
+        [Test]
+        public virtual void ShouldFillGapAtBeginningOfTerm()
+        {
+            const int gapOffset = 0;
+            const int gapLength = 64;
+
+            Assert.IsTrue(TermGapFiller.TryFillGap(metaDataBuffer, termBuffer, TERM_ID, gapOffset, gapLength));
+
+            Assert.That(dataFlyweight.FrameLength(), Is.EqualTo(gapLength));
+            Assert.That(dataFlyweight.TermOffset(), Is.EqualTo(gapOffset));
+            Assert.That(dataFlyweight.SessionId(), Is.EqualTo(SESSION_ID));
+            Assert.That(dataFlyweight.TermId(), Is.EqualTo(TERM_ID));
+            Assert.That(dataFlyweight.HeaderType(), Is.EqualTo(FrameDescriptor.PADDING_FRAME_TYPE));
+            Assert.That(dataFlyweight.Flags(), Is.EqualTo(FrameDescriptor.UNFRAGMENTED));
+        }
+
+        [Test]
+        public virtual void ShouldNotOverwriteExistingFrame()
+        {
+            const int gapOffset = 0;
+            const int gapLength = 64;
+
+            dataFlyweight.FrameLength(32);
+
+            Assert.IsFalse(TermGapFiller.TryFillGap(metaDataBuffer, termBuffer, TERM_ID, gapOffset, gapLength));
+        }
+
+        [Test]
+        public virtual void ShouldFillGapAfterExistingFrame()
+        {
+            const int gapOffset = 128;
+            const int gapLength = 64;
+
+            dataFlyweight.SessionId(SESSION_ID).TermId(TERM_ID).StreamId(STREAM_ID).Flags(FrameDescriptor.UNFRAGMENTED).FrameLength(gapOffset);
+            dataFlyweight.SetMemory(0, gapOffset - DataHeaderFlyweight.HEADER_LENGTH, (byte)'x');
+
+            Assert.IsTrue(TermGapFiller.TryFillGap(metaDataBuffer, termBuffer, TERM_ID, gapOffset, gapLength));
+
+            dataFlyweight.Wrap(termBuffer, gapOffset, termBuffer.Capacity - gapOffset);
+            Assert.That(dataFlyweight.FrameLength(), Is.EqualTo(gapLength));
+            Assert.That(dataFlyweight.TermOffset(), Is.EqualTo(gapOffset));
+            Assert.That(dataFlyweight.SessionId(), Is.EqualTo(SESSION_ID));
+            Assert.That(dataFlyweight.TermId(), Is.EqualTo(TERM_ID));
+            Assert.That(dataFlyweight.HeaderType(), Is.EqualTo(FrameDescriptor.PADDING_FRAME_TYPE));
+            Assert.That(dataFlyweight.Flags(), Is.EqualTo(FrameDescriptor.UNFRAGMENTED));
+        }
+
+        [Test]
+        public virtual void ShouldFillGapBetweenExistingFrames()
+        {
+            const int gapOffset = 128;
+            const int gapLength = 64;
+
+            dataFlyweight.SessionId(SESSION_ID).TermId(TERM_ID).TermOffset(0).StreamId(STREAM_ID).Flags(FrameDescriptor.UNFRAGMENTED).FrameLength(gapOffset).SetMemory(0, gapOffset - DataHeaderFlyweight.HEADER_LENGTH, (byte)'x');
+
+            int secondExistingFrameOffset = gapOffset + gapLength;
+            dataFlyweight.Wrap(termBuffer, secondExistingFrameOffset, termBuffer.Capacity - secondExistingFrameOffset);
+            dataFlyweight.SessionId(SESSION_ID).TermId(TERM_ID).TermOffset(secondExistingFrameOffset).StreamId(STREAM_ID).Flags(FrameDescriptor.UNFRAGMENTED).FrameLength(64);
+
+            Assert.IsTrue(TermGapFiller.TryFillGap(metaDataBuffer, termBuffer, TERM_ID, gapOffset, gapLength));
+
+            dataFlyweight.Wrap(termBuffer, gapOffset, termBuffer.Capacity - gapOffset);
+            Assert.That(dataFlyweight.FrameLength(), Is.EqualTo(gapLength));
+            Assert.That(dataFlyweight.TermOffset(), Is.EqualTo(gapOffset));
+            Assert.That(dataFlyweight.SessionId(), Is.EqualTo(SESSION_ID));
+            Assert.That(dataFlyweight.TermId(), Is.EqualTo(TERM_ID));
+            Assert.That(dataFlyweight.HeaderType(), Is.EqualTo(FrameDescriptor.PADDING_FRAME_TYPE));
+            Assert.That(dataFlyweight.Flags(), Is.EqualTo(FrameDescriptor.UNFRAGMENTED));
+        }
+
+        [Test]
+        public virtual void ShouldFillGapAtEndOfTerm()
+        {
+            int gapOffset = termBuffer.Capacity - 64;
+            const int gapLength = 64;
+
+            dataFlyweight.SessionId(SESSION_ID).TermId(TERM_ID).StreamId(STREAM_ID).Flags(FrameDescriptor.UNFRAGMENTED).FrameLength(termBuffer.Capacity - gapOffset);
+            dataFlyweight.SetMemory(0, gapOffset - DataHeaderFlyweight.HEADER_LENGTH, (byte)'x');
+
+            Assert.IsTrue(TermGapFiller.TryFillGap(metaDataBuffer, termBuffer, TERM_ID, gapOffset, gapLength));
+
+            dataFlyweight.Wrap(termBuffer, gapOffset, termBuffer.Capacity - gapOffset);
+            Assert.That(dataFlyweight.FrameLength(), Is.EqualTo(gapLength));
+            Assert.That(dataFlyweight.TermOffset(), Is.EqualTo(gapOffset));
+            Assert.That(dataFlyweight.SessionId(), Is.EqualTo(SESSION_ID));
+            Assert.That(dataFlyweight.TermId(), Is.EqualTo(TERM_ID));
+            Assert.That(dataFlyweight.HeaderType(), Is.EqualTo(FrameDescriptor.PADDING_FRAME_TYPE));
+            Assert.That((byte)dataFlyweight.Flags(), Is.EqualTo(FrameDescriptor.UNFRAGMENTED));
+        }
+    }
+}

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermReaderTest.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermReaderTest.cs
@@ -18,6 +18,7 @@ using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
+using Adaptive.Agrona.Concurrent.Status;
 using FakeItEasy;
 using NUnit.Framework;
 
@@ -34,6 +35,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         private UnsafeBuffer termBuffer;
         private ErrorHandler errorHandler;
         private FragmentHandler handler;
+        private IPosition subscriberPosition;
 
         [SetUp]
         public void SetUp()
@@ -42,20 +44,9 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             termBuffer = A.Fake<UnsafeBuffer>();
             errorHandler = A.Fake<ErrorHandler>();
             handler = A.Fake<FragmentHandler>();
+            subscriberPosition = A.Fake<IPosition>();
 
             A.CallTo(() => termBuffer.Capacity).Returns(TERM_BUFFER_CAPACITY);
-        }
-
-        [Test]
-        public void ShouldPackPaddingAndOffsetIntoResultingStatus()
-        {
-            const int offset = 77;
-            const int fragmentsRead = 999;
-
-            long scanOutcome = TermReader.Pack(offset, fragmentsRead);
-
-            Assert.That(TermReader.Offset(scanOutcome), Is.EqualTo(offset));
-            Assert.That(TermReader.FragmentsRead(scanOutcome), Is.EqualTo(fragmentsRead));
         }
 
         [Test]
@@ -63,6 +54,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         {
             const int msgLength = 1;
             int frameLength = HEADER_LENGTH + msgLength;
+            int alignedFrameLength = BitUtil.Align(frameLength, FrameDescriptor.FRAME_ALIGNMENT);
             const int termOffset = 0;
 
             A.CallTo(() => termBuffer.GetIntVolatile(0))
@@ -70,11 +62,12 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             A.CallTo(() => termBuffer.GetShort(FrameDescriptor.TypeOffset(0)))
                 .Returns((short)HeaderFlyweight.HDR_TYPE_DATA);
 
-            long readOutcome = TermReader.Read(termBuffer, termOffset, handler, int.MaxValue, header, errorHandler);
+            int readOutcome = TermReader.Read(termBuffer, termOffset, handler, int.MaxValue, header, errorHandler, 0, subscriberPosition);
             Assert.That(TermReader.FragmentsRead(readOutcome), Is.EqualTo(1));
 
-            A.CallTo(() => termBuffer.GetIntVolatile(0)).MustHaveHappened();
-            A.CallTo(() => handler(termBuffer, HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened();
+            A.CallTo(() => termBuffer.GetIntVolatile(0)).MustHaveHappened()
+                .Then(A.CallTo(() => handler(termBuffer, HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened())
+                .Then(A.CallTo(() => subscriberPosition.SetOrdered(alignedFrameLength)).MustHaveHappened());
         }
 
         [Test]
@@ -82,10 +75,11 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         {
             const int termOffset = 0;
 
-            long readOutcome = TermReader.Read(termBuffer, termOffset, handler, int.MaxValue, header, errorHandler);
+            int readOutcome = TermReader.Read(termBuffer, termOffset, handler, int.MaxValue, header, errorHandler, 0, subscriberPosition);
             Assert.That(TermReader.FragmentsRead(readOutcome), Is.EqualTo(0));
             Assert.That(TermReader.Offset(readOutcome), Is.EqualTo(termOffset));
 
+            A.CallTo(() => subscriberPosition.SetOrdered(A<long>._)).MustNotHaveHappened();
             A.CallTo(() => termBuffer.GetIntVolatile(0)).MustHaveHappened();
             A.CallTo(() => handler(A<UnsafeBuffer>._, A<int>._, A<int>._, A<Header>._)).MustNotHaveHappened();
         }
@@ -95,6 +89,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         {
             const int msgLength = 1;
             int frameLength = HEADER_LENGTH + msgLength;
+            int alignedFrameLength = BitUtil.Align(frameLength, FrameDescriptor.FRAME_ALIGNMENT);
             const int termOffset = 0;
 
             A.CallTo(() => termBuffer.GetIntVolatile(A<int>._))
@@ -102,11 +97,12 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             A.CallTo(() => termBuffer.GetShort(A<int>._))
                 .Returns((short)HeaderFlyweight.HDR_TYPE_DATA);
 
-            long readOutcome = TermReader.Read(termBuffer, termOffset, handler, 1, header, errorHandler);
-            Assert.That(TermReader.FragmentsRead(readOutcome), Is.EqualTo(1));
+            int readOutcome = TermReader.Read(termBuffer, termOffset, handler, 1, header, errorHandler, 0, subscriberPosition);
+            Assert.That(readOutcome, Is.EqualTo(1));
 
             A.CallTo(() => termBuffer.GetIntVolatile(0)).MustHaveHappened()
-                .Then(A.CallTo(() => handler(termBuffer, HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened());
+                .Then(A.CallTo(() => handler(termBuffer, HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened())
+                .Then(A.CallTo(() => subscriberPosition.SetOrdered(alignedFrameLength)).MustHaveHappened());
         }
 
         [Test]
@@ -121,14 +117,14 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             A.CallTo(() => termBuffer.GetIntVolatile(alignedFrameLength)).Returns(frameLength);
             A.CallTo(() => termBuffer.GetShort(A<int>._)).Returns((short)HeaderFlyweight.HDR_TYPE_DATA);
 
-            long readOutcome = TermReader.Read(termBuffer, termOffset, handler, int.MaxValue, header, errorHandler);
-            Assert.That(TermReader.FragmentsRead(readOutcome), Is.EqualTo(2));
-            Assert.That(TermReader.Offset(readOutcome), Is.EqualTo(alignedFrameLength * 2));
+            int readOutcome = TermReader.Read(termBuffer, termOffset, handler, int.MaxValue, header, errorHandler, 0, subscriberPosition);
+            Assert.That(readOutcome, Is.EqualTo(2));
 
             A.CallTo(() => termBuffer.GetIntVolatile(0)).MustHaveHappened()
                 .Then(A.CallTo(() => handler(termBuffer, HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened())
                 .Then(A.CallTo(() => termBuffer.GetIntVolatile(alignedFrameLength)).MustHaveHappened())
-                .Then(A.CallTo(() => handler(termBuffer, alignedFrameLength + HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened());
+                .Then(A.CallTo(() => handler(termBuffer, alignedFrameLength + HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened())
+                .Then(A.CallTo(() => subscriberPosition.SetOrdered(alignedFrameLength * 2)).MustHaveHappened());
         }
 
         [Test]
@@ -142,12 +138,12 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             A.CallTo(() => termBuffer.GetIntVolatile(frameOffset)).Returns(frameLength);
             A.CallTo(() => termBuffer.GetShort(FrameDescriptor.TypeOffset(frameOffset))).Returns((short)HeaderFlyweight.HDR_TYPE_DATA);
 
-            long readOutcome = TermReader.Read(termBuffer, frameOffset, handler, int.MaxValue, header, errorHandler);
-            Assert.That(TermReader.FragmentsRead(readOutcome), Is.EqualTo(1));
-            Assert.That(TermReader.Offset(readOutcome), Is.EqualTo(TERM_BUFFER_CAPACITY));
-
+            int readOutcome = TermReader.Read(termBuffer, frameOffset, handler, int.MaxValue, header, errorHandler, 0, subscriberPosition);
+            Assert.That(readOutcome, Is.EqualTo(1));
+            
             A.CallTo(() => termBuffer.GetIntVolatile(frameOffset)).MustHaveHappened()
-                .Then(A.CallTo(() => handler(termBuffer, frameOffset + HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened());
+                .Then(A.CallTo(() => handler(termBuffer, frameOffset + HEADER_LENGTH, msgLength, A<Header>._)).MustHaveHappened())
+                .Then(A.CallTo(() => subscriberPosition.SetOrdered(alignedFrameLength)).MustHaveHappened());
         }
 
         [Test]
@@ -161,11 +157,12 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             A.CallTo(() => termBuffer.GetIntVolatile(frameOffset)).Returns(frameLength);
             A.CallTo(() => termBuffer.GetShort(FrameDescriptor.TypeOffset(frameOffset))).Returns((short)FrameDescriptor.PADDING_FRAME_TYPE);
             
-            long readOutcome = TermReader.Read(termBuffer, frameOffset, handler, int.MaxValue, header, errorHandler);
-            Assert.That(TermReader.FragmentsRead(readOutcome), Is.EqualTo(0));
-            Assert.That(TermReader.Offset(readOutcome), Is.EqualTo(TERM_BUFFER_CAPACITY));
+            int readOutcome = TermReader.Read(termBuffer, frameOffset, handler, int.MaxValue, header, errorHandler, 0, subscriberPosition);
+            Assert.That(readOutcome, Is.EqualTo(0));
 
-            A.CallTo(() => termBuffer.GetIntVolatile(frameOffset)).MustHaveHappened();
+            A.CallTo(() => termBuffer.GetIntVolatile(frameOffset)).MustHaveHappened()
+                .Then(A.CallTo(() => subscriberPosition.SetOrdered(alignedFrameLength)).MustHaveHappened());
+
             A.CallTo(() => handler(A<UnsafeBuffer>._, A<int>._, A<int>._, A<Header>._)).MustNotHaveHappened();
         }
     }

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermReaderTest.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermReaderTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermRebuilderTest.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermRebuilderTest.cs
@@ -1,4 +1,5 @@
 ﻿using Adaptive.Aeron.LogBuffer;
+using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 using FakeItEasy;
@@ -28,13 +29,16 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             const int srcOffset = 0;
             const int length = 256;
             packet.PutInt(srcOffset, length);
-            A.CallTo(() => _termBuffer.GetInt(0)).Returns(length);
 
             TermRebuilder.Insert(_termBuffer, termOffset, packet, length);
-
-            A.CallTo(() => _termBuffer.PutBytes(termOffset, packet, srcOffset, length)).MustHaveHappened()
-                .Then(A.CallTo(() => _termBuffer.PutIntOrdered(termOffset, length)).MustHaveHappened());
+            
+            A.CallTo(() => _termBuffer.PutBytes(termOffset + DataHeaderFlyweight.HEADER_LENGTH, packet, srcOffset + DataHeaderFlyweight.HEADER_LENGTH, length - DataHeaderFlyweight.HEADER_LENGTH)).MustHaveHappened()
+                .Then(A.CallTo(() => _termBuffer.PutLong(termOffset + 24, packet.GetLong(24))).MustHaveHappened())
+                .Then(A.CallTo(() => _termBuffer.PutLong(termOffset + 16, packet.GetLong(16))).MustHaveHappened())
+                .Then(A.CallTo(() => _termBuffer.PutLong(termOffset + 8, packet.GetLong(8))).MustHaveHappened())
+                .Then(A.CallTo(() => _termBuffer.PutLongOrdered(termOffset, packet.GetLong(0))).MustHaveHappened());
         }
+
 
         [Test]
         public void ShouldInsertLastFrameIntoBuffer()
@@ -47,12 +51,9 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             packet.PutShort(FrameDescriptor.TypeOffset(srcOffset), (short)FrameDescriptor.PADDING_FRAME_TYPE);
             packet.PutInt(srcOffset, frameLength);
 
-            A.CallTo(() => _termBuffer.GetInt(tail)).Returns(frameLength);
-            A.CallTo(() => _termBuffer.GetShort(FrameDescriptor.TypeOffset(tail))).Returns((short)FrameDescriptor.PADDING_FRAME_TYPE);
-
             TermRebuilder.Insert(_termBuffer, termOffset, packet, frameLength);
 
-            A.CallTo(() => (_termBuffer).PutBytes(tail, packet, srcOffset, frameLength)).MustHaveHappened();
+            A.CallTo(() => _termBuffer.PutBytes(tail + DataHeaderFlyweight.HEADER_LENGTH, packet, srcOffset + DataHeaderFlyweight.HEADER_LENGTH, frameLength - DataHeaderFlyweight.HEADER_LENGTH)).MustHaveHappened();
         }
 
         [Test]
@@ -65,13 +66,9 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             int termOffset = tail;
             UnsafeBuffer packet = new UnsafeBuffer(new byte[alignedFrameLength]);
 
-            A.CallTo(() => _termBuffer.GetInt(0)).Returns(frameLength);
-            A.CallTo(() => _termBuffer.GetInt(alignedFrameLength)).Returns(frameLength);
-            A.CallTo(() => _termBuffer.GetInt(alignedFrameLength * 2)).Returns(frameLength);
-
             TermRebuilder.Insert(_termBuffer, termOffset, packet, alignedFrameLength);
 
-            A.CallTo(() => (_termBuffer).PutBytes(tail, packet, srcOffset, alignedFrameLength)).MustHaveHappened();
+            A.CallTo(() => _termBuffer.PutBytes(tail + DataHeaderFlyweight.HEADER_LENGTH, packet, srcOffset + DataHeaderFlyweight.HEADER_LENGTH, alignedFrameLength - DataHeaderFlyweight.HEADER_LENGTH)).MustHaveHappened();
         }
 
         [Test]
@@ -83,12 +80,9 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             UnsafeBuffer packet = new UnsafeBuffer(new byte[alignedFrameLength]);
             int termOffset = alignedFrameLength * 2;
 
-            A.CallTo(() => _termBuffer.GetInt(0)).Returns(0);
-            A.CallTo(() => _termBuffer.GetInt(alignedFrameLength)).Returns(frameLength);
-
             TermRebuilder.Insert(_termBuffer, termOffset, packet, alignedFrameLength);
 
-            A.CallTo(() => (_termBuffer).PutBytes(alignedFrameLength * 2, packet, srcOffset, alignedFrameLength)).MustHaveHappened();
+            A.CallTo(() => _termBuffer.PutBytes((alignedFrameLength * 2) + DataHeaderFlyweight.HEADER_LENGTH, packet, srcOffset + DataHeaderFlyweight.HEADER_LENGTH, alignedFrameLength - DataHeaderFlyweight.HEADER_LENGTH)).MustHaveHappened();
         }
 
         [Test]
@@ -99,13 +93,10 @@ namespace Adaptive.Aeron.Tests.LogBuffer
             const int srcOffset = 0;
             UnsafeBuffer packet = new UnsafeBuffer(new byte[alignedFrameLength]);
             int termOffset = alignedFrameLength * 2;
-
-            A.CallTo(() => _termBuffer.GetInt(0)).Returns(frameLength);
-            A.CallTo(() => _termBuffer.GetInt(alignedFrameLength)).Returns(0);
-
+            
             TermRebuilder.Insert(_termBuffer, termOffset, packet, alignedFrameLength);
 
-            A.CallTo(() => (_termBuffer).PutBytes(alignedFrameLength * 2, packet, srcOffset, alignedFrameLength)).MustHaveHappened();
+            A.CallTo(() => _termBuffer.PutBytes((alignedFrameLength * 2) + DataHeaderFlyweight.HEADER_LENGTH, packet, srcOffset + DataHeaderFlyweight.HEADER_LENGTH, alignedFrameLength - DataHeaderFlyweight.HEADER_LENGTH)).MustHaveHappened();
         }
     }
 }

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermRebuilderTest.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermRebuilderTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron.Tests/Properties/AssemblyInfo.cs
+++ b/src/Adaptive.Aeron.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Adaptive.Aeron.Tests/PublicationTest.cs
+++ b/src/Adaptive.Aeron.Tests/PublicationTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.LogBuffer;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Concurrent.Status;
 using FakeItEasy;

--- a/src/Adaptive.Aeron.Tests/PublicationTest.cs
+++ b/src/Adaptive.Aeron.Tests/PublicationTest.cs
@@ -31,6 +31,7 @@ namespace Adaptive.Aeron.Tests
         private const int CorrelationID = 2000;
         private const int SendBufferCapacity = 1024;
         private const int PartionIndex = 0;
+        private const int MTU_LENGTH = 4096;
 
         private byte[] _sendBuffer;
         private UnsafeBuffer _atomicSendBuffer;
@@ -60,6 +61,7 @@ namespace Adaptive.Aeron.Tests
             A.CallTo(() => _logBuffers.MetaDataBuffer()).Returns(_logMetaDataBuffer);
 
             LogBufferDescriptor.InitialTermId(_logMetaDataBuffer, TermID1);
+            LogBufferDescriptor.MtuLength(_logMetaDataBuffer, MTU_LENGTH);
             LogBufferDescriptor.TimeOfLastStatusMessage(_logMetaDataBuffer, 0);
 
             for (var i = 0; i < LogBufferDescriptor.PARTITION_COUNT; i++)

--- a/src/Adaptive.Aeron.Tests/SubscriptionTest.cs
+++ b/src/Adaptive.Aeron.Tests/SubscriptionTest.cs
@@ -41,6 +41,8 @@ namespace Adaptive.Aeron.Tests
         private Image ImageOneMock;
         private Header Header;
         private Image ImageTwoMock;
+        private AvailableImageHandler AvailableImageHandler;
+        private UnavailableImageHandler UnavailableImageHandler;
 
         private Subscription Subscription;
 
@@ -53,10 +55,18 @@ namespace Adaptive.Aeron.Tests
             ImageOneMock = A.Fake<Image>();
             ImageTwoMock = A.Fake<Image>();
             Header = A.Fake<Header>();
+            AvailableImageHandler = A.Fake<AvailableImageHandler>();
+            UnavailableImageHandler = A.Fake<UnavailableImageHandler>();
 
             A.CallTo(() => Header.Flags).Returns(FLAGS);
 
-            Subscription = new Subscription(Conductor, CHANNEL, STREAM_ID_1, SUBSCRIPTION_CORRELATION_ID);
+            Subscription = new Subscription(
+                Conductor, 
+                CHANNEL, 
+                STREAM_ID_1, 
+                SUBSCRIPTION_CORRELATION_ID,
+                AvailableImageHandler,
+                UnavailableImageHandler);
             A.CallTo(() => Conductor.ReleaseSubscription(Subscription));
         }
 

--- a/src/Adaptive.Aeron.Tests/SubscriptionTest.cs
+++ b/src/Adaptive.Aeron.Tests/SubscriptionTest.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron.Tests/packages.config
+++ b/src/Adaptive.Aeron.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.0.0-rc2" targetFramework="net452" />
-  <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.4.2" targetFramework="net452" />
+  <package id="NUnit" version="3.7.1" targetFramework="net452" />
 </packages>

--- a/src/Adaptive.Aeron.sln.DotSettings
+++ b/src/Adaptive.Aeron.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/Adaptive.Aeron/ActivePublications.cs
+++ b/src/Adaptive.Aeron/ActivePublications.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Adaptive.Agrona.Collections;

--- a/src/Adaptive.Aeron/ActivePublications.cs
+++ b/src/Adaptive.Aeron/ActivePublications.cs
@@ -24,7 +24,7 @@ namespace Adaptive.Aeron
     /// <summary>
     /// Map for navigating to active <seealso cref="Publication"/>s.
     /// </summary>
-    public class ActivePublications : IDisposable
+    class ActivePublications : IDisposable
     {
         private readonly IDictionary<string, Dictionary<int, Publication>> _publicationsByChannelMap = 
             new Dictionary<string, Dictionary<int, Publication>>();

--- a/src/Adaptive.Aeron/ActivePublications.cs
+++ b/src/Adaptive.Aeron/ActivePublications.cs
@@ -80,15 +80,15 @@ namespace Adaptive.Aeron
 
         public void Dispose()
         {
-            var publications = from publicationByStreamIdMap in _publicationsByChannelMap.Values
-                from publication in publicationByStreamIdMap.Values
-                select publication;
-
-            foreach (var publication in publications)
+            foreach (var publications in _publicationsByChannelMap.Values)
             {
-                publication.Release();
+                foreach (var publication in publications.Values)
+                {
+                    publication.ForceClose();
+                }
             }
+
+            _publicationsByChannelMap.Clear();
         }
     }
-
 }

--- a/src/Adaptive.Aeron/ActiveSubscriptions.cs
+++ b/src/Adaptive.Aeron/ActiveSubscriptions.cs
@@ -61,14 +61,15 @@ namespace Adaptive.Aeron
 
         public void Dispose()
         {
-            var subscriptions = from subs in _subscriptionsByStreamIdMap.Values
-                from subscription in subs
-                select subscription;
-
-            foreach (var subscription in subscriptions)
+            foreach (var subscriptions in _subscriptionsByStreamIdMap.Values)
             {
-                subscription.Release();
+                for (int i = 0, size = subscriptions.Count; i < size; i++)
+                {
+                    subscriptions[i].ForceClose();
+                }
             }
+
+            _subscriptionsByStreamIdMap.Clear();
         }
     }
 }

--- a/src/Adaptive.Aeron/ActiveSubscriptions.cs
+++ b/src/Adaptive.Aeron/ActiveSubscriptions.cs
@@ -67,7 +67,7 @@ namespace Adaptive.Aeron
 
             foreach (var subscription in subscriptions)
             {
-                subscription.Dispose();
+                subscription.Release();
             }
         }
     }

--- a/src/Adaptive.Aeron/ActiveSubscriptions.cs
+++ b/src/Adaptive.Aeron/ActiveSubscriptions.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Adaptive.Aeron/Adaptive.Aeron.csproj
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.csproj
@@ -119,7 +119,9 @@
       <Name>Adaptive.Agrona</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Adaptive.Aeron/Adaptive.Aeron.csproj
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.csproj
@@ -63,6 +63,7 @@
     <Compile Include="ActivePublications.cs" />
     <Compile Include="ActiveSubscriptions.cs" />
     <Compile Include="Aeron.cs" />
+    <Compile Include="ListUtil.cs" />
     <Compile Include="BufferBuilder.cs" />
     <Compile Include="ClientConductor.cs" />
     <Compile Include="CncFileDescriptor.cs" />
@@ -100,11 +101,13 @@
     <Compile Include="LogBuffer\LogBufferDescriptor.cs" />
     <Compile Include="LogBuffer\TermAppender.cs" />
     <Compile Include="LogBuffer\TermBlockScanner.cs" />
+    <Compile Include="LogBuffer\TermGapFiller.cs" />
     <Compile Include="LogBuffer\TermReader.cs" />
     <Compile Include="MappedLogBuffersFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protocol\DataHeaderFlyweight.cs" />
     <Compile Include="Protocol\HeaderFlyweight.cs" />
+    <Compile Include="Protocol\RttMeasurementFlyweight.cs" />
     <Compile Include="Publication.cs" />
     <Compile Include="ReservedValueSupplier.cs" />
     <Compile Include="Subscription.cs" />

--- a/src/Adaptive.Aeron/Adaptive.Aeron.csproj
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.csproj
@@ -63,6 +63,7 @@
     <Compile Include="ActivePublications.cs" />
     <Compile Include="ActiveSubscriptions.cs" />
     <Compile Include="Aeron.cs" />
+    <Compile Include="Command\DestinationMessageFlyweight.cs" />
     <Compile Include="ListUtil.cs" />
     <Compile Include="BufferBuilder.cs" />
     <Compile Include="ClientConductor.cs" />

--- a/src/Adaptive.Aeron/Adaptive.Aeron.csproj
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.csproj
@@ -64,7 +64,6 @@
     <Compile Include="ActiveSubscriptions.cs" />
     <Compile Include="Aeron.cs" />
     <Compile Include="Command\DestinationMessageFlyweight.cs" />
-    <Compile Include="ListUtil.cs" />
     <Compile Include="BufferBuilder.cs" />
     <Compile Include="ClientConductor.cs" />
     <Compile Include="CncFileDescriptor.cs" />
@@ -86,13 +85,18 @@
     <Compile Include="Exceptions\DriverTimeoutException.cs" />
     <Compile Include="Exceptions\RegistrationException.cs" />
     <Compile Include="FragmentAssembler.cs" />
+    <Compile Include="ImageControlledFragmentHandler.cs" />
+    <Compile Include="ImageFragmentAssembler.cs" />
     <Compile Include="ImageHandlers.cs" />
     <Compile Include="IDriverListener.cs" />
     <Compile Include="ILogBuffersFactory.cs" />
     <Compile Include="Image.cs" />
+    <Compile Include="ListUtil.cs" />
     <Compile Include="LogBuffers.cs" />
     <Compile Include="LogBuffer\BufferClaim.cs" />
     <Compile Include="LogBuffer\ControlledFragmentHandlerAction.cs" />
+    <Compile Include="LogBuffer\ExclusiveBufferClaim.cs" />
+    <Compile Include="LogBuffer\ExclusiveTermAppender.cs" />
     <Compile Include="LogBuffer\FrameDescriptor.cs" />
     <Compile Include="LogBuffer\Header.cs" />
     <Compile Include="LogBuffer\HeaderWriter.cs" />
@@ -109,6 +113,7 @@
     <Compile Include="Protocol\DataHeaderFlyweight.cs" />
     <Compile Include="Protocol\HeaderFlyweight.cs" />
     <Compile Include="Protocol\RttMeasurementFlyweight.cs" />
+    <Compile Include="ExclusivePublication.cs" />
     <Compile Include="Publication.cs" />
     <Compile Include="ReservedValueSupplier.cs" />
     <Compile Include="Subscription.cs" />

--- a/src/Adaptive.Aeron/Adaptive.Aeron.licenseheader
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Adaptive.Aeron/Aeron.cs
+++ b/src/Adaptive.Aeron/Aeron.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.IO;
-using System.Threading;
 using Adaptive.Aeron.Exceptions;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
@@ -342,15 +341,25 @@ namespace Adaptive.Aeron
 
 
             /// <summary>
-            /// Set the <seealso cref="EpochClock"/> to be used for tracking wall clock time when interacting with the driver.
+            /// Set the <seealso cref="IEpochClock"/> to be used for tracking wall clock time when interacting with the driver.
             /// </summary>
-            /// <param name="clock"> <seealso cref="EpochClock"/> to be used for tracking wall clock time when interacting with the driver. </param>
+            /// <param name="clock"> <seealso cref="IEpochClock"/> to be used for tracking wall clock time when interacting with the driver. </param>
             /// <returns> this Aeron.Context for method chaining </returns>
             public Context EpochClock(IEpochClock clock)
             {
                 _epochClock = clock;
                 return this;
             }
+
+            /// <summary>
+            /// Get the <seealso cref="IEpochClock"/> used by the client for the epoch time in milliseconds.
+            /// </summary>
+            /// <returns> the <seealso cref="IEpochClock"/> used by the client for the epoch time in milliseconds. </returns>
+            public IEpochClock EpochClock()
+            {
+                return _epochClock;
+            }
+
 
             /// <summary>
             /// Set the <seealso cref="NanoClock"/> to be used for tracking high resolution time.
@@ -372,6 +381,15 @@ namespace Adaptive.Aeron
             {
                 _idleStrategy = idleStrategy;
                 return this;
+            }
+
+            /// <summary>
+            /// Get the <seealso cref="IIdleStrategy"/> employed by the client conductor thread.
+            /// </summary>
+            /// <returns> the <seealso cref="IIdleStrategy"/> employed by the client conductor thread. </returns>
+            public IIdleStrategy IdleStrategy()
+            {
+                return _idleStrategy;
             }
 
             /// <summary>
@@ -419,6 +437,15 @@ namespace Adaptive.Aeron
             {
                 _errorHandler = errorHandler;
                 return this;
+            }
+
+            /// <summary>
+            /// Get the error handler that will be called for errors reported back from the media driver.
+            /// </summary>
+            /// <returns> the error handler that will be called for errors reported back from the media driver. </returns>
+            public ErrorHandler ErrorHandler()
+            {
+                return _errorHandler;
             }
 
             /// <summary>

--- a/src/Adaptive.Aeron/Aeron.cs
+++ b/src/Adaptive.Aeron/Aeron.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.IO;
 using System.Threading;
 using Adaptive.Aeron.Exceptions;

--- a/src/Adaptive.Aeron/Aeron.cs
+++ b/src/Adaptive.Aeron/Aeron.cs
@@ -243,6 +243,26 @@ namespace Adaptive.Aeron
             /// </summary>
             public const long DEFAULT_DRIVER_TIMEOUT_MS = 10000;
 
+            /// <summary>
+            /// The param name to be used for the term length as a channel URI param.
+            /// </summary>
+            public const string TERM_LENGTH_PARAM_NAME = "term-length";
+
+            /// <summary>
+            /// MTU length parameter name for using as a channel URI param.
+            /// </summary>
+            public const string MTU_LENGTH_URI_PARAM_NAME = "mtu";
+
+            /// <summary>
+            /// Key for the mode of control that such be used for multi-destination-cast semantics.
+            /// </summary>
+            public const string MDC_CONTROL_MODE = "control-mode";
+
+            /// <summary>
+            /// Valid value for <seealso cref="MDC_CONTROL_MODE"/> when manual control is desired.
+            /// </summary>
+            public const string MDC_CONTROL_MODE_MANUAL = "manual";
+
             public Context()
             {
                 _aeronDirectoryName = Config.GetProperty(AERON_DIR_PROP_NAME, AERON_DIR_PROP_DEFAULT);

--- a/src/Adaptive.Aeron/BufferBuilder.cs
+++ b/src/Adaptive.Aeron/BufferBuilder.cs
@@ -15,9 +15,11 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
+using Adaptive.Agrona.Util;
 
 namespace Adaptive.Aeron
 {
@@ -84,11 +86,12 @@ namespace Adaptive.Aeron
         /// Set this limit for this buffer as the position at which the next append operation will occur.
         /// </summary>
         /// <param name="limit"> to be the new value. </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Limit(int limit)
         {
             if (limit < 0 || limit >= _capacity)
             {
-                throw new ArgumentException($"Limit outside range: capacity={_capacity:D} limit={limit:D}");
+                ThrowHelper.ThrowArgumentException($"Limit outside range: capacity={_capacity:D} limit={limit:D}");
             }
 
             _limit = limit;
@@ -150,7 +153,7 @@ namespace Adaptive.Aeron
             if (requiredCapacity < 0)
             {
                 string s = $"Insufficient capacity: limit={_limit:D} additional={additionalCapacity:D}";
-                throw new InvalidOperationException(s);
+                ThrowHelper.ThrowInvalidOperationException(s);
             }
 
             if (requiredCapacity > _capacity)
@@ -174,7 +177,7 @@ namespace Adaptive.Aeron
                 {
                     if (capacity == MAX_CAPACITY)
                     {
-                        throw new InvalidOperationException("Max capacity reached: " + MAX_CAPACITY);
+                        ThrowHelper.ThrowInvalidOperationException("Max capacity reached: " + MAX_CAPACITY);
                     }
 
                     capacity = MAX_CAPACITY;

--- a/src/Adaptive.Aeron/BufferBuilder.cs
+++ b/src/Adaptive.Aeron/BufferBuilder.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 

--- a/src/Adaptive.Aeron/ClientConductor.cs
+++ b/src/Adaptive.Aeron/ClientConductor.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Adaptive.Aeron.Exceptions;
 using Adaptive.Aeron.io.aeron;
@@ -358,6 +359,7 @@ namespace Adaptive.Aeron
             _lingeringResources.Add(managedResource);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsPublicationConnected(long timeOfLastStatusMessageMs)
         {
             return _epochClock.Time() <= (timeOfLastStatusMessageMs + _publicationConnectionTimeoutMs);

--- a/src/Adaptive.Aeron/ClientConductor.cs
+++ b/src/Adaptive.Aeron/ClientConductor.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Adaptive.Aeron.Exceptions;

--- a/src/Adaptive.Aeron/CncFileDescriptor.cs
+++ b/src/Adaptive.Aeron/CncFileDescriptor.cs
@@ -42,7 +42,7 @@ namespace Adaptive.Aeron
     ///  +----------------------------+
     /// </pre>
     /// 
-    /// Meta Data Layout (CnC Version 4)
+    /// Meta Data Layout (CnC Version 6)
     /// <pre>
     ///  +----------------------------+
     ///  |   to-driver buffer length  |
@@ -64,7 +64,7 @@ namespace Adaptive.Aeron
     {
         public const string CNC_FILE = "cnc.dat";
 
-        public const int CNC_VERSION = 5;
+        public const int CNC_VERSION = 6;
 
         public static readonly int CNC_VERSION_FIELD_OFFSET;
         public static readonly int CNC_METADATA_OFFSET;

--- a/src/Adaptive.Aeron/CncFileDescriptor.cs
+++ b/src/Adaptive.Aeron/CncFileDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Util;
 

--- a/src/Adaptive.Aeron/Command/ControlProtocolEvents.cs
+++ b/src/Adaptive.Aeron/Command/ControlProtocolEvents.cs
@@ -17,52 +17,83 @@
 namespace Adaptive.Aeron.Command
 {
     /// <summary>
-    /// List of event types used in the control protocol between the
-    /// media driver and the core.
+    /// List of events used in the control protocol between client and the media driver.
     /// </summary>
     public class ControlProtocolEvents
     {
         // Clients to Media Driver
 
         /// <summary>
-        /// Add Publication </summary>
+        /// Add Publication.
+        /// </summary>
         public const int ADD_PUBLICATION = 0x01;
+
         /// <summary>
-        /// Remove Publication </summary>
+        /// Remove Publication.
+        /// </summary>
         public const int REMOVE_PUBLICATION = 0x02;
+
         /// <summary>
-        /// Add Subscriber </summary>
+        /// Add an Exclusive Publication.
+        /// </summary>
+        public const int ADD_EXCLUSIVE_PUBLICATION = 0x03;
+
+        /// <summary>
+        /// Add a Subscriber.
+        /// </summary>
         public const int ADD_SUBSCRIPTION = 0x04;
+
         /// <summary>
-        /// Remove Subscriber </summary>
+        /// Remove a Subscriber.
+        /// </summary>
         public const int REMOVE_SUBSCRIPTION = 0x05;
+
         /// <summary>
-        /// Keepalive from Client </summary>
+        /// Keepalive from Client.
+        /// </summary>
         public const int CLIENT_KEEPALIVE = 0x06;
+
         /// <summary>
-        /// Add Destination </summary>
+        /// Add Destination to an existing Publication.
+        /// </summary>
         public const int ADD_DESTINATION = 0x07;
+
         /// <summary>
-        /// Remove Destination </summary>
+        /// Remove Destination from an existing Publication.
+        /// </summary>
         public const int REMOVE_DESTINATION = 0x08;
 
         // Media Driver to Clients
 
         /// <summary>
-        /// Error Response </summary>
+        /// Error Response as a result of attempting to process a client command operation.
+        /// </summary>
         public const int ON_ERROR = 0x0F01;
+
         /// <summary>
-        /// New subscription Buffer Notification </summary>
+        /// Subscribed Image buffers are available notification.
+        /// </summary>
         public const int ON_AVAILABLE_IMAGE = 0x0F02;
+        
         /// <summary>
-        /// New publication Buffer Notification </summary>
+        /// New Publication buffers are ready notification.
+        /// </summary>
         public const int ON_PUBLICATION_READY = 0x0F03;
+
         /// <summary>
-        /// Operation Succeeded </summary>
+        /// Operation has succeeded.
+        /// </summary>
         public const int ON_OPERATION_SUCCESS = 0x0F04;
+
         /// <summary>
-        /// Inform client of timeout and removal of inactive image </summary>
+        /// Inform client of timeout and removal of an inactive Image.
+        /// </summary>
         public const int ON_UNAVAILABLE_IMAGE = 0x0F05;
+
+        /// <summary>
+        /// New Exclusive Publication buffers are ready notification.
+        /// </summary>
+        public const int ON_EXCLUSIVE_PUBLICATION_READY = 0x0F06;
     }
 
 }

--- a/src/Adaptive.Aeron/Command/ControlProtocolEvents.cs
+++ b/src/Adaptive.Aeron/Command/ControlProtocolEvents.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Aeron.Command
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Aeron.Command
 {
     /// <summary>
     /// List of event types used in the control protocol between the

--- a/src/Adaptive.Aeron/Command/ControlProtocolEvents.cs
+++ b/src/Adaptive.Aeron/Command/ControlProtocolEvents.cs
@@ -39,6 +39,12 @@ namespace Adaptive.Aeron.Command
         /// <summary>
         /// Keepalive from Client </summary>
         public const int CLIENT_KEEPALIVE = 0x06;
+        /// <summary>
+        /// Add Destination </summary>
+        public const int ADD_DESTINATION = 0x07;
+        /// <summary>
+        /// Remove Destination </summary>
+        public const int REMOVE_DESTINATION = 0x08;
 
         // Media Driver to Clients
 

--- a/src/Adaptive.Aeron/Command/CorrelatedMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/CorrelatedMessageFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/DestinationMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/DestinationMessageFlyweight.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
+
+namespace Adaptive.Aeron.Command
+{
+    public class DestinationMessageFlyweight : CorrelatedMessageFlyweight
+    {
+        private static readonly int REGISTRATION_CORRELATION_ID_OFFSET = CORRELATION_ID_FIELD_OFFSET + BitUtil.SIZE_OF_LONG;
+        private static readonly int CHANNEL_OFFSET = REGISTRATION_CORRELATION_ID_OFFSET + BitUtil.SIZE_OF_LONG;
+
+        private int lengthOfChannel;
+
+        /// <summary>
+        /// return correlation id used in registration field
+        /// </summary>
+        /// <returns> correlation id field </returns>
+        public long RegistrationCorrelationId()
+        {
+            return buffer.GetLong(offset + REGISTRATION_CORRELATION_ID_OFFSET);
+        }
+
+        /// <summary>
+        /// set registration correlation id field
+        /// </summary>
+        /// <param name="correlationId"> field value </param>
+        /// <returns> flyweight </returns>
+        public DestinationMessageFlyweight RegistrationCorrelationId(long correlationId)
+        {
+            buffer.PutLong(offset + REGISTRATION_CORRELATION_ID_OFFSET, correlationId);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Get the channel field in ASCII
+        /// </summary>
+        /// <returns> channel field </returns>
+        public string Channel()
+        {
+            return buffer.GetStringAscii(offset + CHANNEL_OFFSET);
+        }
+
+        /// <summary>
+        /// Set channel field in ASCII
+        /// </summary>
+        /// <param name="channel"> field value </param>
+        /// <returns> flyweight </returns>
+        public DestinationMessageFlyweight Channel(string channel)
+        {
+            lengthOfChannel = buffer.PutStringAscii(offset + CHANNEL_OFFSET, channel);
+
+            return this;
+        }
+
+        public int Length()
+        {
+            return CHANNEL_OFFSET + lengthOfChannel;
+        }
+    }
+}

--- a/src/Adaptive.Aeron/Command/ErrorResponseFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/ErrorResponseFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/ImageBuffersReadyFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/ImageBuffersReadyFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/ImageBuffersReadyFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/ImageBuffersReadyFlyweight.cs
@@ -34,17 +34,17 @@ namespace Adaptive.Aeron.Command
     /// |                                                               |
     /// +---------------------------------------------------------------+
     /// |                                                              ...
-    /// ...     Up to "Position Indicators Count" entries of this form
+    /// ...     Up to "Position Indicators Count" entries of this form  |
     /// +---------------------------------------------------------------+
     /// |                         Log File Length                       |
     /// +---------------------------------------------------------------+
-    /// |                          Log File Name                       ...
-    /// ...                                                              |
+    /// |                          Log File Name (ASCII)               ...
+    /// ...                                                             |
     /// +---------------------------------------------------------------+
     /// |                     Source identity Length                    |
     /// +---------------------------------------------------------------+
-    /// |                     Source identity Name                     ...
-    /// ...                                                              |
+    /// |                     Source identity (ASCII)                  ...
+    /// ...                                                             |
     /// +---------------------------------------------------------------+ 
     public class ImageBuffersReadyFlyweight
     {
@@ -216,42 +216,42 @@ namespace Adaptive.Aeron.Command
         }
 
         /// <summary>
-        /// Return the Log Filename
+        /// Return the Log Filename in ASCII
         /// </summary>
         /// <returns> log filename </returns>
         public string LogFileName()
         {
-            return _buffer.GetStringUtf8(_offset + LogFileNameOffset());
+            return _buffer.GetStringAscii(_offset + LogFileNameOffset());
         }
 
         /// <summary>
-        /// Set the log filename
+        /// Set the log filename in ASCII
         /// </summary>
         /// <param name="logFileName"> for the image </param>
         /// <returns> flyweight </returns>
         public ImageBuffersReadyFlyweight LogFileName(string logFileName)
         {
-            _buffer.PutStringUtf8(_offset + LogFileNameOffset(), logFileName);
+            _buffer.PutStringAscii(_offset + LogFileNameOffset(), logFileName);
             return this;
         }
 
         /// <summary>
-        /// Return the source identity string
+        /// Return the source identity string in ASCII
         /// </summary>
         /// <returns> source identity string </returns>
         public string SourceIdentity()
         {
-            return _buffer.GetStringUtf8(_offset + SourceIdentityOffset());
+            return _buffer.GetStringAscii(_offset + SourceIdentityOffset());
         }
 
         /// <summary>
-        /// Set the source identity string
+        /// Set the source identity string in ASCII
         /// </summary>
         /// <param name="value"> for the source identity </param>
         /// <returns> flyweight </returns>
         public ImageBuffersReadyFlyweight SourceIdentity(string value)
         {
-            _buffer.PutStringUtf8(_offset + SourceIdentityOffset(), value);
+            _buffer.PutStringAscii(_offset + SourceIdentityOffset(), value);
             return this;
         }
 

--- a/src/Adaptive.Aeron/Command/ImageMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/ImageMessageFlyweight.cs
@@ -16,7 +16,7 @@ namespace Adaptive.Aeron.Command
     /// +---------------------------------------------------------------+
     /// |                        Channel Length                         |
     /// +---------------------------------------------------------------+
-    /// |                           Channel                           ...
+    /// |                           Channel (ASCII)                    ...
     /// ...                                                             |
     /// +---------------------------------------------------------------+
     /// </para>
@@ -86,7 +86,7 @@ namespace Adaptive.Aeron.Command
         }
 
         /// <summary>
-        /// return channel field
+        /// Get the channel field as ASCII
         /// </summary>
         /// <returns> channel field </returns>
         public string Channel()
@@ -94,17 +94,17 @@ namespace Adaptive.Aeron.Command
             int length = buffer.GetInt(offset + CHANNEL_OFFSET);
             lengthOfChannel = BitUtil.SIZE_OF_INT + length;
 
-            return buffer.GetStringUtf8(offset + CHANNEL_OFFSET, length);
+            return buffer.GetStringAscii(offset + CHANNEL_OFFSET, length);
         }
 
         /// <summary>
-        /// set channel field
+        /// Set the channel field as ASCII
         /// </summary>
         /// <param name="channel"> field value </param>
         /// <returns> flyweight </returns>
         public ImageMessageFlyweight Channel(string channel)
         {
-            lengthOfChannel = buffer.PutStringUtf8(offset + CHANNEL_OFFSET, channel);
+            lengthOfChannel = buffer.PutStringAscii(offset + CHANNEL_OFFSET, channel);
 
             return this;
         }

--- a/src/Adaptive.Aeron/Command/ImageMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/ImageMessageFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/PublicationBuffersReadyFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/PublicationBuffersReadyFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/PublicationBuffersReadyFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/PublicationBuffersReadyFlyweight.cs
@@ -21,7 +21,7 @@ namespace Adaptive.Aeron.Command
     /// +---------------------------------------------------------------+
     /// |                         Log File Length                       |
     /// +---------------------------------------------------------------+
-    /// |                          Log File Name                      ...
+    /// |                          Log File Name (ASCII)               ...
     /// ...                                                             |
     /// +---------------------------------------------------------------+ 
     public class PublicationBuffersReadyFlyweight
@@ -133,14 +133,23 @@ namespace Adaptive.Aeron.Command
             return this;
         }
 
+        /// <summary>
+        /// Get the log file name in ASCII.
+        /// </summary>
+        /// <returns> the log file name in ASCII. </returns>
         public string LogFileName()
         {
-            return _buffer.GetStringUtf8(_offset + LOGFILE_FIELD_OFFSET);
+            return _buffer.GetStringAscii(_offset + LOGFILE_FIELD_OFFSET);
         }
 
+        /// <summary>
+        /// Set the log file name in ASCII.
+        /// </summary>
+        /// <param name="logFileName"> for the publication buffers. </param>
+        /// <returns> the log file name in ASCII. </returns>
         public PublicationBuffersReadyFlyweight LogFileName(string logFileName)
         {
-            _buffer.PutStringUtf8(_offset + LOGFILE_FIELD_OFFSET, logFileName);
+            _buffer.PutStringAscii(_offset + LOGFILE_FIELD_OFFSET, logFileName);
             return this;
         }
 

--- a/src/Adaptive.Aeron/Command/PublicationMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/PublicationMessageFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/PublicationMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/PublicationMessageFlyweight.cs
@@ -16,8 +16,8 @@ namespace Adaptive.Aeron.Command
     /// +---------------------------------------------------------------+
     /// |                        Channel Length                         |
     /// +---------------------------------------------------------------+
-    /// |                           Channel                            ...
-    /// ...                                                              |
+    /// |                           Channel   (ASCII)                  ...
+    /// ...                                                             |
     /// +---------------------------------------------------------------+
     /// </para>
     /// </summary>
@@ -50,22 +50,22 @@ namespace Adaptive.Aeron.Command
         }
 
         /// <summary>
-        /// Get the channel field
+        /// Get the channel field in ASCII
         /// </summary>
         /// <returns> channel field </returns>
         public string Channel()
         {
-            return buffer.GetStringUtf8(offset + CHANNEL_OFFSET);
+            return buffer.GetStringAscii(offset + CHANNEL_OFFSET);
         }
 
         /// <summary>
-        /// Set the channel field
+        /// Set the channel field in ASCII
         /// </summary>
         /// <param name="channel"> field value </param>
         /// <returns> flyweight </returns>
         public PublicationMessageFlyweight Channel(string channel)
         {
-            _lengthOfChannel = buffer.PutStringUtf8(offset + CHANNEL_OFFSET, channel);
+            _lengthOfChannel = buffer.PutStringAscii(offset + CHANNEL_OFFSET, channel);
 
             return this;
         }

--- a/src/Adaptive.Aeron/Command/RemoveMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/RemoveMessageFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/SubscriptionMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/SubscriptionMessageFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.Command
 {

--- a/src/Adaptive.Aeron/Command/SubscriptionMessageFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/SubscriptionMessageFlyweight.cs
@@ -5,20 +5,20 @@ namespace Adaptive.Aeron.Command
     /// <summary>
     /// Control message for adding or removing a subscription.
     /// 
-    /// <para>
     /// 0                   1                   2                   3
     /// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     /// |                    Command Correlation ID                     |
     /// +---------------------------------------------------------------+
-    /// |                  Registration Correlation ID                  |
+    /// |                 Registration Correlation ID                   |
     /// +---------------------------------------------------------------+
-    /// |                           Stream Id                           |
+    /// |                         Stream Id                             |
     /// +---------------------------------------------------------------+
-    /// |       Channel Length         |   Channel                     ...
-    /// |                                                              ...
+    /// |                       Channel Length                          |
     /// +---------------------------------------------------------------+
-    /// </para>
+    /// |                       Channel (ASCII)                        ...
+    /// ...                                                              |
+    /// +---------------------------------------------------------------+
     /// </summary>
     public class SubscriptionMessageFlyweight : CorrelatedMessageFlyweight
     {
@@ -73,22 +73,22 @@ namespace Adaptive.Aeron.Command
         }
 
         /// <summary>
-        /// return the channel field
+        /// Get the channel field in ASCII
         /// </summary>
         /// <returns> channel field </returns>
         public string Channel()
         {
-            return buffer.GetStringUtf8(offset + CHANNEL_OFFSET);
+            return buffer.GetStringAscii(offset + CHANNEL_OFFSET);
         }
 
         /// <summary>
-        /// Set channel field
+        /// Set channel field in ASCII
         /// </summary>
         /// <param name="channel"> field value </param>
         /// <returns> flyweight </returns>
         public SubscriptionMessageFlyweight Channel(string channel)
         {
-            _lengthOfChannel = buffer.PutStringUtf8(offset + CHANNEL_OFFSET, channel);
+            _lengthOfChannel = buffer.PutStringAscii(offset + CHANNEL_OFFSET, channel);
 
             return this;
         }

--- a/src/Adaptive.Aeron/Config.cs
+++ b/src/Adaptive.Aeron/Config.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Adaptive.Aeron/ControlledFragmentAssembler.cs
+++ b/src/Adaptive.Aeron/ControlledFragmentAssembler.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/DriverListenerAdapter.cs
+++ b/src/Adaptive.Aeron/DriverListenerAdapter.cs
@@ -1,4 +1,20 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
 using Adaptive.Aeron.Command;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent.Broadcast;

--- a/src/Adaptive.Aeron/DriverProxy.cs
+++ b/src/Adaptive.Aeron/DriverProxy.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Aeron.Command;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron/DriverProxy.cs
+++ b/src/Adaptive.Aeron/DriverProxy.cs
@@ -75,11 +75,36 @@ namespace Adaptive.Aeron
 
             _publicationMessage.CorrelationId(correlationId);
 
-            _publicationMessage.StreamId(streamId).Channel(channel);
+            _publicationMessage
+                .StreamId(streamId)
+                .Channel(channel);
 
             if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_PUBLICATION, _buffer, 0, _publicationMessage.Length()))
             {
                 throw new InvalidOperationException("Could not write add publication command");
+            }
+
+            return correlationId;
+        }
+
+
+#if DEBUG
+        public virtual long AddExclusivePublication(string channel, int streamId)
+#else
+        public long AddExclusivePublication(string channel, int streamId)
+#endif
+        {
+            long correlationId = _toDriverCommandBuffer.NextCorrelationId();
+
+            _publicationMessage.CorrelationId(correlationId);
+
+            _publicationMessage
+                .StreamId(streamId)
+                .Channel(channel);
+
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_EXCLUSIVE_PUBLICATION, _buffer, 0, _publicationMessage.Length()))
+            {
+                throw new InvalidOperationException("Could not write add exclusive publication command");
             }
 
             return correlationId;

--- a/src/Adaptive.Aeron/ErrorCode.cs
+++ b/src/Adaptive.Aeron/ErrorCode.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Aeron
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Aeron
 {
     /// <summary>
     /// Error codes between media driver and client and the on-wire protocol.

--- a/src/Adaptive.Aeron/ErrorCode.cs
+++ b/src/Adaptive.Aeron/ErrorCode.cs
@@ -22,16 +22,20 @@ namespace Adaptive.Aeron
     public enum ErrorCode
     {
         /// <summary>
-        /// Aeron encountered an error condition. </summary>
+        /// Aeron encountered an error condition. 
+        /// </summary>
         GENERIC_ERROR = 0,
         /// <summary>
-        /// A failure occurred creating a new channel or parsing the channel string. </summary>
+        /// A failure occurred creating a new channel or parsing the channel string. 
+        /// </summary>
         INVALID_CHANNEL = 1,
         /// <summary>
-        /// Attempted to remove a subscription, but it was not found </summary>
+        /// Attempted to remove a subscription, but it was not found 
+        /// </summary>
         UNKNOWN_SUBSCRIPTION = 2,
         /// <summary>
-        /// Attempted to remove a publication, but it was not found. </summary>
+        /// Attempted to remove a publication, but it was not found. 
+        /// </summary>
         UNKNOWN_PUBLICATION = 3
     }
 }

--- a/src/Adaptive.Aeron/Exceptions/ConductorServiceTimeoutException.cs
+++ b/src/Adaptive.Aeron/Exceptions/ConductorServiceTimeoutException.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Aeron.Exceptions
 {

--- a/src/Adaptive.Aeron/Exceptions/DriverTimeoutException.cs
+++ b/src/Adaptive.Aeron/Exceptions/DriverTimeoutException.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Aeron.Exceptions
 {

--- a/src/Adaptive.Aeron/Exceptions/RegistrationException.cs
+++ b/src/Adaptive.Aeron/Exceptions/RegistrationException.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Aeron.Exceptions
 {

--- a/src/Adaptive.Aeron/ExclusivePublication.cs
+++ b/src/Adaptive.Aeron/ExclusivePublication.cs
@@ -448,7 +448,7 @@ namespace Adaptive.Aeron
         {
             if (length > MaxPayloadLength)
             {
-                throw new ArgumentException(
+                ThrowHelper.ThrowArgumentException(
                     $"Claim exceeds maxPayloadLength of {MaxPayloadLength:D}, length={length:D}");
             }
         }
@@ -458,7 +458,7 @@ namespace Adaptive.Aeron
         {
             if (length > MaxMessageLength)
             {
-                throw new ArgumentException(
+                ThrowHelper.ThrowArgumentException(
                     $"Mssage exceeds maxMessageLength of {MaxMessageLength:D}, length={length:D}");
             }
         }

--- a/src/Adaptive.Aeron/FragmentAssembler.cs
+++ b/src/Adaptive.Aeron/FragmentAssembler.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/IDriverListener.cs
+++ b/src/Adaptive.Aeron/IDriverListener.cs
@@ -19,16 +19,37 @@ using System.Collections.Generic;
 namespace Adaptive.Aeron
 {
     /// <summary>
-    /// Callback interface for receiving messages from the driver.
+    /// Callback interface for dispatching command responses from the driver on the control protocol.
     /// </summary>
     internal interface IDriverListener
     {
-        void OnNewPublication(string channel, int streamId, int sessionId, int publicationLimitId, string logFileName, long correlationId);
+        void OnError(ErrorCode errorCode, string message, long correlationId);
 
-        void OnAvailableImage(int streamId, int sessionId, IDictionary<long, long> subscriberPositionMap, string logFileName, string sourceIdentity, long correlationId);
+        void OnAvailableImage(
+            int streamId, 
+            int sessionId, 
+            Dictionary<long, long> subscriberPositionMap, 
+            string logFileName, 
+            string sourceIdentity, 
+            long correlationId);
+
+        void OnNewPublication(
+            string channel, 
+            int streamId, 
+            int sessionId, 
+            int publicationLimitId, 
+            string logFileName, 
+            long correlationId);
 
         void OnUnavailableImage(int streamId, long correlationId);
 
-        void OnError(ErrorCode errorCode, string message, long correlationId);
+        void OnNewExclusivePublication(
+            string channel, 
+            int streamId, 
+            int sessionId, 
+            int publicationLimitId, 
+            string logFileName, 
+            long correlationId);
     }
+
 }

--- a/src/Adaptive.Aeron/IDriverListener.cs
+++ b/src/Adaptive.Aeron/IDriverListener.cs
@@ -1,4 +1,20 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
 
 namespace Adaptive.Aeron
 {

--- a/src/Adaptive.Aeron/ILogBuffersFactory.cs
+++ b/src/Adaptive.Aeron/ILogBuffersFactory.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron

--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -11,6 +11,14 @@ namespace Adaptive.Aeron
     /// <summary>
     /// Represents a replicated publication <seealso cref="Image"/> from a publisher to a <seealso cref="Subscription"/>.
     /// Each <seealso cref="Image"/> identifies a source publisher by session id.
+    /// 
+    /// By default fragmented messages are not reassembled before delivery. If an application must
+    /// receive whole messages, whether or not they were fragmented, then the Subscriber
+    /// should be created with a <seealso cref="FragmentAssembler"/> or a custom implementation.
+    /// 
+    /// It is an application's responsibility to <seealso cref="Poll"/> the <seealso cref="Image"/> for new messages.
+    /// 
+    /// <b>Note:</b>Images are not threadsafe and should not be shared between subscribers.
     /// </summary>
     public class Image
     {

--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
@@ -127,6 +128,7 @@ namespace Adaptive.Aeron
         /// The position this <seealso cref="Image"/> has been consumed to by the subscriber.
         /// </summary>
         /// <returns> the position this <seealso cref="Image"/> has been consumed to by the subscriber. </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long Position()
         {
             if (_isClosed)
@@ -141,11 +143,12 @@ namespace Adaptive.Aeron
         /// Set the subscriber position for this <seealso cref="Image"/> to indicate where it has been consumed to.
         /// </summary>
         /// <param name="newPosition"> for the consumption point. </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Position(long newPosition)
         {
             if (_isClosed)
             {
-                throw new InvalidOperationException("Image is closed");
+                ThrowHelper.ThrowInvalidOperationException("Image is closed");
             }
 
             ValidatePosition(newPosition);
@@ -465,18 +468,19 @@ namespace Adaptive.Aeron
             return _termBuffers[LogBufferDescriptor.IndexByPosition(position, _positionBitsToShift)];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ValidatePosition(long newPosition)
         {
             long currentPosition = _subscriberPosition.Get();
             long limitPosition = currentPosition + TermBufferLength;
             if (newPosition < currentPosition || newPosition > limitPosition)
             {
-                throw new ArgumentException("newPosition of " + newPosition + " out of range " + currentPosition + "-" + limitPosition);
+                ThrowHelper.ThrowArgumentException("newPosition of " + newPosition + " out of range " + currentPosition + "-" + limitPosition);
             }
 
             if(0 != (newPosition & (FrameDescriptor.FRAME_ALIGNMENT - 1)))
             {
-                throw new ArgumentException("newPosition of " + newPosition + " not aligned to FRAME_ALIGNMENT");
+                ThrowHelper.ThrowArgumentException("newPosition of " + newPosition + " not aligned to FRAME_ALIGNMENT");
             }
         }
 

--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/ImageControlledFragmentHandler.cs
+++ b/src/Adaptive.Aeron/ImageControlledFragmentHandler.cs
@@ -1,0 +1,100 @@
+﻿using Adaptive.Aeron.LogBuffer;
+using Adaptive.Agrona;
+
+namespace Adaptive.Aeron
+{
+    /// <summary>
+    /// A <seealso cref="IControlledFragmentHandler"/> that sits in a chain-of-responsibility pattern that reassembles fragmented
+    /// messages so that the next handler in the chain only sees whole messages. This is for a single session on an
+    /// <seealso cref="Image"/> and not for multiple session <seealso cref="Image"/>s in a <seealso cref="Subscription"/>.
+    /// 
+    /// Unfragmented messages are delegated without copy. Fragmented messages are copied to a temporary
+    /// buffer for reassembly before delegation.
+    /// 
+    /// The <seealso cref="Header"/> passed to the delegate on assembling a message will be that of the last fragment.
+    /// </summary>
+    /// <see cref="Image.ControlledPoll(IControlledFragmentHandler, int)"/>
+    /// <see cref="Image.ControlledPeek(long, IControlledFragmentHandler, long)"/>
+    public class ImageControlledFragmentAssembler : IControlledFragmentHandler
+    {
+        private readonly IControlledFragmentHandler _delegate;
+        private readonly BufferBuilder _builder;
+
+        /// <summary>
+        /// Construct an adapter to reassembly message fragments and delegate on only whole messages.
+        /// </summary>
+        /// <param name="delegate">            onto which whole messages are forwarded. </param>
+        /// <param name="initialBufferLength"> to be used for each session. </param>
+        public ImageControlledFragmentAssembler(IControlledFragmentHandler @delegate, int initialBufferLength = BufferBuilder.INITIAL_CAPACITY)
+        {
+            _delegate = @delegate;
+            _builder = new BufferBuilder(initialBufferLength);
+        }
+
+        /// <summary>
+        /// Get the delegate unto which assembled messages are delegated.
+        /// </summary>
+        /// <returns>  the delegate unto which assembled messages are delegated. </returns>
+        public virtual IControlledFragmentHandler Delegate()
+        {
+            return _delegate;
+        }
+
+        /// <summary>
+        /// Get the <see cref="BufferBuilder"/> for resetting this assembler.
+        /// </summary>
+        /// <returns> the <see cref="BufferBuilder"/> for resetting this assembler</returns>
+        public BufferBuilder Builder()
+        {
+            return _builder;
+        }
+
+        /// <summary>
+        /// The implementation of <seealso cref="IControlledFragmentHandler"/> that reassembles and forwards whole messages.
+        /// </summary>
+        /// <param name="buffer"> containing the data. </param>
+        /// <param name="offset"> at which the data begins. </param>
+        /// <param name="length"> of the data in bytes. </param>
+        /// <param name="header"> representing the meta data for the data. </param>
+        public ControlledFragmentHandlerAction OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
+        {
+            byte flags = header.Flags;
+
+            var action = ControlledFragmentHandlerAction.CONTINUE;
+
+            if ((flags & FrameDescriptor.UNFRAGMENTED) == FrameDescriptor.UNFRAGMENTED)
+            {
+                action = _delegate.OnFragment(buffer, offset, length, header);
+            }
+            else
+            {
+                if ((flags & FrameDescriptor.BEGIN_FRAG_FLAG) == FrameDescriptor.BEGIN_FRAG_FLAG)
+                {
+                    _builder.Reset().Append(buffer, offset, length);
+                }
+                else
+                {
+                    int limit = _builder.Limit();
+                    _builder.Append(buffer, offset, length);
+
+                    if ((flags & FrameDescriptor.END_FRAG_FLAG) == FrameDescriptor.END_FRAG_FLAG)
+                    {
+                        int msgLength = _builder.Limit();
+                        action = _delegate.OnFragment(_builder.Buffer(), 0, msgLength, header);
+
+                        if (ControlledFragmentHandlerAction.ABORT == action)
+                        {
+                            _builder.Limit(limit);
+                        }
+                        else
+                        {
+                            _builder.Reset();
+                        }
+                    }
+                }
+            }
+
+            return action;
+        }
+    }
+}

--- a/src/Adaptive.Aeron/ImageFragmentAssembler.cs
+++ b/src/Adaptive.Aeron/ImageFragmentAssembler.cs
@@ -38,18 +38,16 @@ namespace Adaptive.Aeron
     /// <see cref="Subscription.Poll"/>
     /// <see cref="Image.Poll"/>
     /// </summary>
-    public class FragmentAssembler
+    public class ImageFragmentAssembler
     {
-        private readonly int _initialBufferLength;
         private readonly FragmentHandler _delegate;
-        private readonly Dictionary<int, BufferBuilder> _builderBySessionIdMap = new Dictionary<int, BufferBuilder>();
-        
+        private readonly BufferBuilder _builder;
 
         /// <summary>
         /// Construct an adapter to reassemble message fragments and delegate on whole messages.
         /// </summary>
         /// <param name="fragmentHandler"> onto which whole messages are forwarded. </param>
-        public FragmentAssembler(FragmentHandler fragmentHandler) : this(fragmentHandler, BufferBuilder.INITIAL_CAPACITY)
+        public ImageFragmentAssembler(FragmentHandler fragmentHandler) : this(fragmentHandler, BufferBuilder.INITIAL_CAPACITY)
         {
         }
 
@@ -58,10 +56,10 @@ namespace Adaptive.Aeron
         /// </summary>
         /// <param name="fragmentHandler">            onto which whole messages are forwarded. </param>
         /// <param name="initialBufferLength"> to be used for each session. </param>
-        public FragmentAssembler(FragmentHandler fragmentHandler, int initialBufferLength)
+        public ImageFragmentAssembler(FragmentHandler fragmentHandler, int initialBufferLength)
         {
-            _initialBufferLength = initialBufferLength;
             _delegate = fragmentHandler;
+            _builder = new BufferBuilder(initialBufferLength);
         }
 
         /// <summary>
@@ -71,6 +69,15 @@ namespace Adaptive.Aeron
         public FragmentHandler Delegate()
         {
             return _delegate;
+        }
+
+        /// <summary>
+        /// Get the <see cref="BufferBuilder"/> for resetting this assembler.
+        /// </summary>
+        /// <returns> the <see cref="BufferBuilder"/> for resetting this assembler</returns>
+        public BufferBuilder Builder()
+        {
+            return _builder;
         }
 
         /// <summary>
@@ -98,70 +105,20 @@ namespace Adaptive.Aeron
         {
             if ((flags & FrameDescriptor.BEGIN_FRAG_FLAG) == FrameDescriptor.BEGIN_FRAG_FLAG)
             {
-                BufferBuilder builder;
-                if (!_builderBySessionIdMap.TryGetValue(header.SessionId, out builder))
-                {
-                    builder = GetBufferBuilder(header.SessionId);
-                    _builderBySessionIdMap[header.SessionId] = builder;
-                }
-
-                builder.Reset().Append(buffer, offset, length);
+                _builder.Reset().Append(buffer, offset, length);
             }
             else
             {
 
-                BufferBuilder builder;
-                _builderBySessionIdMap.TryGetValue(header.SessionId, out builder);
-                if (null != builder && builder.Limit() != 0)
-                {
-                    builder.Append(buffer, offset, length);
+                _builder.Append(buffer, offset, length);
 
-                    if ((flags & FrameDescriptor.END_FRAG_FLAG) == FrameDescriptor.END_FRAG_FLAG)
-                    {
-                        int msgLength = builder.Limit();
-                        _delegate(builder.Buffer(), 0, msgLength, header);
-                        builder.Reset();
-                    }
+                if ((flags & FrameDescriptor.END_FRAG_FLAG) == FrameDescriptor.END_FRAG_FLAG)
+                {
+                    int msgLength = _builder.Limit();
+                    _delegate(_builder.Buffer(), 0, msgLength, header);
+                    _builder.Reset();
                 }
             }
-        }
-
-        /// <summary>
-        /// Free an existing session buffer to reduce memory pressure when an image goes inactive or no more
-        /// large messages are expected.
-        /// </summary>
-        /// <param name="sessionId"> to have its buffer freed </param>
-        /// <returns> true if a buffer has been freed otherwise false. </returns>
-        public bool FreeSessionBuffer(int sessionId)
-        {
-            if (_builderBySessionIdMap.ContainsKey(sessionId))
-            {
-                _builderBySessionIdMap.Remove(sessionId);
-                return true;
-            }
-            return false;
-        }
-        /// <summary>
-        /// Clear down the cache of buffers by session for reassembling messages.
-        /// </summary>
-        public void Clear()
-        {
-            _builderBySessionIdMap.Clear();
-        }
-
-        private BufferBuilder GetBufferBuilder(int sessionId)
-        {
-            BufferBuilder bufferBuilder;
-
-            _builderBySessionIdMap.TryGetValue(sessionId, out bufferBuilder);
-
-            if (null == bufferBuilder)
-            {
-                bufferBuilder = new BufferBuilder(_initialBufferLength);
-                _builderBySessionIdMap[sessionId] = bufferBuilder;
-            }
-
-            return bufferBuilder;
         }
     }
 }

--- a/src/Adaptive.Aeron/ImageHandlers.cs
+++ b/src/Adaptive.Aeron/ImageHandlers.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Aeron
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Aeron
 {
     /// <summary>
     /// Interface for delivery of new image events to a <seealso cref="Aeron"/> instance.

--- a/src/Adaptive.Aeron/ImageHandlers.cs
+++ b/src/Adaptive.Aeron/ImageHandlers.cs
@@ -17,12 +17,18 @@
 namespace Adaptive.Aeron
 {
     /// <summary>
-    /// Interface for delivery of new image events to a <seealso cref="Aeron"/> instance.
+    /// Interface for notification of new <see cref="Image"/>s becoming available under a <see cref="Subscription"/>
+    /// 
+    /// Method called by Aeron to deliver notification of a new <see cref="Image"/> being available for polling.
+    /// <param name="image"> that is now available.</param>
     /// </summary>
     public delegate void AvailableImageHandler(Image image);
 
     /// <summary>
-    /// Interface for delivery of inactive image events to a <seealso cref="Subscription"/>.
+    /// Interface for delivery of inactive image notification to a <seealso cref="Subscription"/>.
+    /// 
+    /// Method called by Aeron to deliver notification that an <see cref="Image"/> is no longer available for polling.
     /// </summary>
+    /// <param name="image"> the image that has become unavailable.</param>
     public delegate void UnavailableImageHandler(Image image);
 }

--- a/src/Adaptive.Aeron/ListUtil.cs
+++ b/src/Adaptive.Aeron/ListUtil.cs
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
+using System;
+
 namespace Adaptive.Aeron
 {
     using System.Collections.Generic;
 
     namespace io.aeron
     {
-        public abstract class ListUtil
+        public static class ListUtil
         {
-            private ListUtil()
-            {
-            }
-
             /// <summary>
             /// Removes element at i, but instead of copying all elements to the left, moves into the same slot the last
             /// element. If i is the last element it is just removed. This avoids the copy costs, but spoils the list order.
@@ -42,7 +40,28 @@ namespace Adaptive.Aeron
                     list[i] = last;
                 }
             }
+
+            /// <summary>
+            /// Removes element at i, but instead of copying all elements to the left, moves into the same slot the last
+            /// element. If i is the last element it is just removed. This avoids the copy costs, but spoils the list order.
+            /// </summary>
+            /// <param name="list">      to be modified </param>
+            /// <param name="e">         to be removed </param>
+            /// <returns> true if found and removed, false otherwise </returns>
+            public static bool FastUnorderedRemove<T>(List<T> list, T e)
+            {
+                if (e == null) throw new ArgumentNullException(nameof(e));
+
+                for (int i = 0, size = list.Count; i < size; i++)
+                {
+                    if (e.Equals(list[i]))
+                    {
+                        FastUnorderedRemove(list, i, size - 1);
+                        return true;
+                    }
+                }
+                return false;
+            }
         }
     }
-
 }

--- a/src/Adaptive.Aeron/ListUtil.cs
+++ b/src/Adaptive.Aeron/ListUtil.cs
@@ -1,0 +1,32 @@
+﻿namespace Adaptive.Aeron
+{
+    using System.Collections.Generic;
+
+    namespace io.aeron
+    {
+        public abstract class ListUtil
+        {
+            private ListUtil()
+            {
+            }
+
+            /// <summary>
+            /// Removes element at i, but instead of copying all elements to the left, moves into the same slot the last
+            /// element. If i is the last element it is just removed. This avoids the copy costs, but spoils the list order.
+            /// </summary>
+            /// <param name="list">      to be modified </param>
+            /// <param name="i">         removal index </param>
+            /// <param name="lastIndex"> last element index </param>
+            public static void FastUnorderedRemove<T>(List<T> list, int i, int lastIndex)
+            {
+                T last = list[lastIndex];
+                list.RemoveAt(lastIndex);
+                if (i != lastIndex)
+                {
+                    list[i] = last;
+                }
+            }
+        }
+    }
+
+}

--- a/src/Adaptive.Aeron/ListUtil.cs
+++ b/src/Adaptive.Aeron/ListUtil.cs
@@ -25,12 +25,14 @@ namespace Adaptive.Aeron
         public static class ListUtil
         {
             /// <summary>
-            /// Removes element at i, but instead of copying all elements to the left, moves into the same slot the last
-            /// element. If i is the last element it is just removed. This avoids the copy costs, but spoils the list order.
+            /// Removes element at index i, but instead of copying all elements to the left, moves into the same slot the last
+            /// element. This avoids the copy costs, but spoils the list order. If i is the last element it is just removed.
             /// </summary>
-            /// <param name="list">      to be modified </param>
-            /// <param name="i">         removal index </param>
-            /// <param name="lastIndex"> last element index </param>
+            /// <param name="list">      to be modified.</param>
+            /// <param name="i">         removal index.</param>
+            /// <param name="lastIndex"> last element index.</param>
+            /// <typeparam name="T">     element type.</typeparam>
+            /// <exception cref="IndexOutOfRangeException"> if i or lastIndex are out of bounds.</exception>
             public static void FastUnorderedRemove<T>(List<T> list, int i, int lastIndex)
             {
                 T last = list[lastIndex];
@@ -42,12 +44,13 @@ namespace Adaptive.Aeron
             }
 
             /// <summary>
-            /// Removes element at i, but instead of copying all elements to the left, moves into the same slot the last
-            /// element. If i is the last element it is just removed. This avoids the copy costs, but spoils the list order.
+            /// Removes element but instead of copying all elements to the left, moves into the same slot the last element.
+            /// This avoids the copy costs, but spoils the list order. If e is the last element it is just removed.
             /// </summary>
-            /// <param name="list">      to be modified </param>
-            /// <param name="e">         to be removed </param>
-            /// <returns> true if found and removed, false otherwise </returns>
+            /// <param name="list">      to be modified.</param>
+            /// <param name="e">         to be removed.</param>
+            /// <typeparam name="T">     element type.</typeparam>
+            /// <returns> true if found and removed, false otherwise.</returns>
             public static bool FastUnorderedRemove<T>(List<T> list, T e)
             {
                 if (e == null) throw new ArgumentNullException(nameof(e));
@@ -60,6 +63,7 @@ namespace Adaptive.Aeron
                         return true;
                     }
                 }
+
                 return false;
             }
         }

--- a/src/Adaptive.Aeron/ListUtil.cs
+++ b/src/Adaptive.Aeron/ListUtil.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Aeron
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Aeron
 {
     using System.Collections.Generic;
 

--- a/src/Adaptive.Aeron/ListUtil.cs
+++ b/src/Adaptive.Aeron/ListUtil.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using Adaptive.Agrona.Util;
 
 namespace Adaptive.Aeron
 {
@@ -53,7 +54,10 @@ namespace Adaptive.Aeron
             /// <returns> true if found and removed, false otherwise.</returns>
             public static bool FastUnorderedRemove<T>(List<T> list, T e)
             {
-                if (e == null) throw new ArgumentNullException(nameof(e));
+                if (e == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(nameof(e));
+                }
 
                 for (int i = 0, size = list.Count; i < size; i++)
                 {

--- a/src/Adaptive.Aeron/LogBuffer/BufferClaim.cs
+++ b/src/Adaptive.Aeron/LogBuffer/BufferClaim.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;

--- a/src/Adaptive.Aeron/LogBuffer/ControlledFragmentHandlerAction.cs
+++ b/src/Adaptive.Aeron/LogBuffer/ControlledFragmentHandlerAction.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.LogBuffer
 {

--- a/src/Adaptive.Aeron/LogBuffer/ControlledFragmentHandlerAction.cs
+++ b/src/Adaptive.Aeron/LogBuffer/ControlledFragmentHandlerAction.cs
@@ -38,8 +38,8 @@ namespace Adaptive.Aeron.LogBuffer
         COMMIT,
 
         /// <summary>
-        /// Continue processing taking the same approach as the in
-        /// <seealso cref="FragmentHandler.OnFragment(IDirectBuffer, int, int, Header)"/>.
+        /// Continue processing until fragment limit or no fragments with position commit at end of poll as the in
+        /// <seealso cref="FragmentHandler"/>.
         /// </summary>
         CONTINUE,
     }

--- a/src/Adaptive.Aeron/LogBuffer/ExclusiveBufferClaim.cs
+++ b/src/Adaptive.Aeron/LogBuffer/ExclusiveBufferClaim.cs
@@ -1,20 +1,4 @@
-﻿/*
- * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0S
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-using System;
+﻿using System;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
@@ -24,14 +8,19 @@ namespace Adaptive.Aeron.LogBuffer
     /// <summary>
     /// Represents a claimed range in a buffer to be used for recording a message without copy semantics for later commit.
     /// 
+    /// <seealso cref="ExclusiveBufferClaim"/>s offer additional functionality over standard <seealso cref="BufferClaim"/>s in that the header
+    /// can be manipulated for setting flags and type. This allows the user to implement things such as their own
+    /// fragmentation policy.
+    /// 
     /// The claimed space is in <seealso cref="Buffer()"/> between <seealso cref="Offset()"/> and <seealso cref="Offset()"/> + <seealso cref="Length()"/>.
     /// When the buffer is filled with message data, use <seealso cref="Commit()"/> to make it available to subscribers.
     /// 
     /// If the claimed space is no longer required it can be aborted by calling <seealso cref="Abort()"/>.
     /// 
-    /// <see cref="Publication.TryClaim"/>
+    /// <a href="https://github.com/real-logic/Aeron/wiki/Protocol-Specification#data-frame">Data Frame</a>
     /// </summary>
-    public class BufferClaim
+    /// <seealso cref="ExclusivePublication.TryClaim(int, ExclusiveBufferClaim)"/>
+    public class ExclusiveBufferClaim
     {
         private readonly UnsafeBuffer _buffer = new UnsafeBuffer(IntPtr.Zero, 0);
 
@@ -41,7 +30,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="buffer"> to be wrapped. </param>
         /// <param name="offset"> at which the claimed region begins including space for the header. </param>
         /// <param name="length"> length of the underlying claimed region including space for the header. </param>
-        public void Wrap(IAtomicBuffer buffer, int offset, int length)
+        public void Wrap(UnsafeBuffer buffer, int offset, int length)
         {
             _buffer.Wrap(buffer, offset, length);
         }
@@ -50,26 +39,79 @@ namespace Adaptive.Aeron.LogBuffer
         /// The referenced buffer to be used.
         /// </summary>
         /// <returns> the referenced buffer to be used.. </returns>
-        public IMutableDirectBuffer Buffer => _buffer;
+        public UnsafeBuffer Buffer()
+        {
+            return _buffer;
+        }
 
         /// <summary>
         /// The offset in the buffer at which the claimed range begins.
         /// </summary>
         /// <returns> offset in the buffer at which the range begins. </returns>
-        public int Offset => DataHeaderFlyweight.HEADER_LENGTH;
-
+        public int Offset()
+        {
+            return DataHeaderFlyweight.HEADER_LENGTH;
+        }
 
         /// <summary>
         /// The length of the claimed range in the buffer.
         /// </summary>
         /// <returns> length of the range in the buffer. </returns>
-        public int Length => _buffer.Capacity - DataHeaderFlyweight.HEADER_LENGTH;
+        public int Length()
+        {
+            return _buffer.Capacity - DataHeaderFlyweight.HEADER_LENGTH;
+        }
 
+        /// <summary>
+        /// Get the value of the flags field. The lower 8 bits are valid.
+        /// </summary>
+        /// <returns> the value of the header flags field. </returns>
+        /// <seealso cref="DataHeaderFlyweight"/>
+        public short Flags()
+        {
+            return (short)(_buffer.GetByte(HeaderFlyweight.FLAGS_FIELD_OFFSET) & 0xFF);
+        }
+
+        /// <summary>
+        /// Set the value of the header flags field. The lower 8 bits are valid.
+        /// </summary>
+        /// <param name="flags"> value to be set in the header. </param>
+        /// <returns> this for a fluent API. </returns>
+        /// <seealso cref="DataHeaderFlyweight"/>
+        public ExclusiveBufferClaim Flags(short flags)
+        {
+            _buffer.PutByte(HeaderFlyweight.FLAGS_FIELD_OFFSET, (byte)flags);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Get the value of the header type field. The lower 16 bits are valid.
+        /// </summary>
+        /// <returns> the value of the header type field. </returns>
+        /// <seealso cref="DataHeaderFlyweight"/>
+        public int HeaderType()
+        {
+            return _buffer.GetShort(HeaderFlyweight.TYPE_FIELD_OFFSET) & 0xFFFF;
+        }
+
+        /// <summary>
+        /// Set the value of the header type field. The lower 16 bits are valid.
+        /// </summary>
+        /// <param name="type"> value to be set in the header. </param>
+        /// <returns> this for a fluent API. </returns>
+        /// <seealso cref="DataHeaderFlyweight"/>
+        public ExclusiveBufferClaim HeaderType(int type)
+        {
+            _buffer.PutShort(HeaderFlyweight.TYPE_FIELD_OFFSET, (short)type);
+
+            return this;
+        }
 
         /// <summary>
         /// Get the value stored in the reserve space at the end of a data frame header.
         /// 
-        /// Note: The value is in <seealso cref="ByteOrder.LittleEndian"/> format.
+        /// Note: The value is in <seealso cref="ByteOrder#LITTLE_ENDIAN"/> format.
         /// </summary>
         /// <returns> the value stored in the reserve space at the end of a data frame header. </returns>
         /// <seealso cref="DataHeaderFlyweight"/>
@@ -81,12 +123,12 @@ namespace Adaptive.Aeron.LogBuffer
         /// <summary>
         /// Write the provided value into the reserved space at the end of the data frame header.
         /// 
-        /// Note: The value will be written in <seealso cref="ByteOrder.LittleEndian"/> format.
+        /// Note: The value will be written in <seealso cref="ByteOrder#LITTLE_ENDIAN"/> format.
         /// </summary>
         /// <param name="value"> to be stored in the reserve space at the end of a data frame header. </param>
         /// <returns> this for fluent API semantics. </returns>
-        /// <seealso cref="DataHeaderFlyweight" />
-        public BufferClaim ReservedValue(long value)
+        /// <seealso cref="DataHeaderFlyweight"/>
+        public ExclusiveBufferClaim ReservedValue(long value)
         {
             _buffer.PutLong(DataHeaderFlyweight.RESERVED_VALUE_OFFSET, value);
             return this;
@@ -97,8 +139,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// </summary>
         public void Commit()
         {
-            var frameLength = _buffer.Capacity;
-
+            int frameLength = _buffer.Capacity;
             _buffer.PutIntOrdered(HeaderFlyweight.FRAME_LENGTH_FIELD_OFFSET, frameLength);
         }
 
@@ -107,10 +148,10 @@ namespace Adaptive.Aeron.LogBuffer
         /// </summary>
         public void Abort()
         {
-            var frameLength = _buffer.Capacity;
-
-            _buffer.PutShort(HeaderFlyweight.TYPE_FIELD_OFFSET, (short) HeaderFlyweight.HDR_TYPE_PAD);
+            int frameLength = _buffer.Capacity;
+            _buffer.PutShort(HeaderFlyweight.TYPE_FIELD_OFFSET, (short)HeaderFlyweight.HDR_TYPE_PAD);
             _buffer.PutIntOrdered(HeaderFlyweight.FRAME_LENGTH_FIELD_OFFSET, frameLength);
         }
     }
+
 }

--- a/src/Adaptive.Aeron/LogBuffer/FragmentHandler.cs
+++ b/src/Adaptive.Aeron/LogBuffer/FragmentHandler.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron.LogBuffer

--- a/src/Adaptive.Aeron/LogBuffer/FrameDescriptor.cs
+++ b/src/Adaptive.Aeron/LogBuffer/FrameDescriptor.cs
@@ -111,6 +111,16 @@ namespace Adaptive.Aeron.LogBuffer
         }
 
         /// <summary>
+        /// Compute the maximum supported message length for a buffer of given capacity when the publication is exclusive.
+        /// </summary>
+        /// <param name="capacity"> of the log buffer. </param>
+        /// <returns> the maximum supported length for a message. </returns>
+        public static int ComputeExclusiveMaxMessageLength(int capacity)
+        {
+            return capacity / 4;
+        }
+
+        /// <summary>
         /// The buffer offset at which the length field begins.
         /// </summary>
         /// <param name="termOffset"> at which the frame begins. </param>

--- a/src/Adaptive.Aeron/LogBuffer/FrameDescriptor.cs
+++ b/src/Adaptive.Aeron/LogBuffer/FrameDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona.Concurrent;
 

--- a/src/Adaptive.Aeron/LogBuffer/Header.cs
+++ b/src/Adaptive.Aeron/LogBuffer/Header.cs
@@ -26,7 +26,9 @@ namespace Adaptive.Aeron.LogBuffer
     public class Header
     {
         private readonly int _positionBitsToShift;
-        private int _initialTermId;
+        private readonly int _initialTermId;
+        private int _offset;
+        private IDirectBuffer _buffer;
 
         public Header()
         {
@@ -65,16 +67,6 @@ namespace Adaptive.Aeron.LogBuffer
             return _initialTermId;
         }
 
-        /// <summary>
-        /// Set the initial term id this stream started at.
-        /// </summary>
-        /// <param name="initialTermId"> this stream started at. </param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void InitialTermId(int initialTermId)
-        {
-            _initialTermId = initialTermId;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetBuffer(IDirectBuffer buffer, int offset)
         {
@@ -85,13 +77,26 @@ namespace Adaptive.Aeron.LogBuffer
         /// <summary>
         /// The offset at which the frame begins.
         /// </summary>
-        public int Offset { get; private set; }
-        
+        public int Offset
+        {
+            get { return _offset; }
+            set { _offset = value; }
+        }
+
         /// <summary>
         /// The <seealso cref="IDirectBuffer"/> containing the header.
         /// </summary>
-        public IDirectBuffer Buffer { get; private set; }
-
+        public IDirectBuffer Buffer
+        {
+            get { return _buffer; }
+            set {
+                if (value != _buffer)
+                {
+                    _buffer = value;
+                }
+            }
+        }
+        
         /// <summary>
         /// The total length of the frame including the header.
         /// </summary>

--- a/src/Adaptive.Aeron/LogBuffer/Header.cs
+++ b/src/Adaptive.Aeron/LogBuffer/Header.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 

--- a/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
+++ b/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/LogBuffer/IBlockHandler.cs
+++ b/src/Adaptive.Aeron/LogBuffer/IBlockHandler.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.LogBuffer
 {

--- a/src/Adaptive.Aeron/LogBuffer/IControlledFragmentHandler.cs
+++ b/src/Adaptive.Aeron/LogBuffer/IControlledFragmentHandler.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.Remoting.Messaging;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.Remoting.Messaging;
 using Adaptive.Agrona;
 
 namespace Adaptive.Aeron.LogBuffer

--- a/src/Adaptive.Aeron/LogBuffer/LogBufferDescriptor.cs
+++ b/src/Adaptive.Aeron/LogBuffer/LogBufferDescriptor.cs
@@ -244,7 +244,7 @@ namespace Adaptive.Aeron.LogBuffer
         }
 
         /// <summary>
-        /// Get the value of the correlation ID for this log.
+        /// Get the value of the correlation ID for this log relating to the command which created it.
         /// </summary>
         /// <param name="logMetaDataBuffer"> containing the meta data. </param>
         /// <returns> the value of the correlation ID used for this log. </returns>
@@ -255,7 +255,7 @@ namespace Adaptive.Aeron.LogBuffer
         }
 
         /// <summary>
-        /// Set the correlation ID used for this log.
+        /// Set the correlation ID used for this log relating to the command which created it.
         /// </summary>
         /// <param name="logMetaDataBuffer"> containing the meta data. </param>
         /// <param name="id">                value to be set. </param>
@@ -441,7 +441,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// </summary>
         /// <param name="logMetaDataBuffer"> into which the default headers should be stored. </param>
         /// <param name="defaultHeader">     to be stored. </param>
-        /// <exception cref="ArgumentException"> if the default header is larger than <seealso cref="LOG_DEFAULT_FRAME_HEADER_MAX_LENGTH"/> </exception>
+        /// <exception cref="ArgumentException"> if the defaultHeader is larger than <seealso cref="LOG_DEFAULT_FRAME_HEADER_MAX_LENGTH"/> </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void StoreDefaultFrameHeader(UnsafeBuffer logMetaDataBuffer, IDirectBuffer defaultHeader)
         {

--- a/src/Adaptive.Aeron/LogBuffer/LogBufferDescriptor.cs
+++ b/src/Adaptive.Aeron/LogBuffer/LogBufferDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/LogBuffer/LogBufferDescriptor.cs
+++ b/src/Adaptive.Aeron/LogBuffer/LogBufferDescriptor.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
+using Adaptive.Agrona.Util;
 
 namespace Adaptive.Aeron.LogBuffer
 {
@@ -188,13 +189,14 @@ namespace Adaptive.Aeron.LogBuffer
             if (termLength < TERM_MIN_LENGTH)
             {
                 string s = $"Term length less than min length of {TERM_MIN_LENGTH:D}, length={termLength:D}";
-                throw new InvalidOperationException(s);
+                ThrowHelper.ThrowInvalidOperationException(s);
+                return;
             }
 
             if ((termLength & (FrameDescriptor.FRAME_ALIGNMENT - 1)) != 0)
             {
                 string s = $"Term length not a multiple of {FrameDescriptor.FRAME_ALIGNMENT:D}, length={termLength:D}";
-                throw new InvalidOperationException(s);
+                ThrowHelper.ThrowInvalidOperationException(s);
             }
         }
 
@@ -457,8 +459,9 @@ namespace Adaptive.Aeron.LogBuffer
         {
             if (defaultHeader.Capacity != DataHeaderFlyweight.HEADER_LENGTH)
             {
-                throw new ArgumentException(
+                ThrowHelper.ThrowArgumentException(
                     $"Default header of {defaultHeader.Capacity:D} not equal to {DataHeaderFlyweight.HEADER_LENGTH:D}");
+                return;
             }
 
             logMetaDataBuffer.PutInt(LOG_DEFAULT_FRAME_HEADER_LENGTH_OFFSET, DataHeaderFlyweight.HEADER_LENGTH);

--- a/src/Adaptive.Aeron/LogBuffer/TermAppender.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermAppender.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/LogBuffer/TermBlockScanner.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermBlockScanner.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron.LogBuffer

--- a/src/Adaptive.Aeron/LogBuffer/TermBlockScanner.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermBlockScanner.cs
@@ -28,11 +28,12 @@ namespace Adaptive.Aeron.LogBuffer
         /// Scan a term buffer for a block of messages from and offset up to a limit.
         /// </summary>
         /// <param name="termBuffer"> to scan for messages. </param>
-        /// <param name="offset">     at which the scan should begin. </param>
+        /// <param name="termOffset">     at which the scan should begin. </param>
         /// <param name="limit">      at which the scan should stop. </param>
         /// <returns> the offset at which the scan terminated. </returns>
-        public static int Scan(IAtomicBuffer termBuffer, int offset, int limit)
+        public static int Scan(IAtomicBuffer termBuffer, int termOffset, int limit)
         {
+            var offset = termOffset;
             do
             {
                 int frameLength = FrameDescriptor.FrameLengthVolatile(termBuffer, offset);

--- a/src/Adaptive.Aeron/LogBuffer/TermGapFiller.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermGapFiller.cs
@@ -1,0 +1,48 @@
+﻿using Adaptive.Aeron.Protocol;
+using Adaptive.Agrona.Concurrent;
+
+namespace Adaptive.Aeron.LogBuffer
+{
+    namespace io.aeron.logbuffer
+    {
+        /// <summary>
+        /// Fills a gap in a term with a padding record.
+        /// </summary>
+        public class TermGapFiller
+        {
+            /// <summary>
+            /// Try to gap fill the current term at a given offset if the gap contains no data.
+            /// 
+            /// Note: the gap offset plus gap length must end on a <seealso cref="FrameDescriptor.FRAME_ALIGNMENT"/> boundary.
+            /// </summary>
+            /// <param name="logMetaDataBuffer"> containing the default headers </param>
+            /// <param name="termBuffer">        to gap fill </param>
+            /// <param name="termId">            for the current term. </param>
+            /// <param name="gapOffset">         to fill from </param>
+            /// <param name="gapLength">         to length of the gap. </param>
+            /// <returns> true if the gap has been filled with a padding record or false if data found. </returns>
+            public static bool TryFillGap(UnsafeBuffer logMetaDataBuffer, UnsafeBuffer termBuffer, int termId, int gapOffset, int gapLength)
+            {
+                int offset = gapOffset + gapLength - FrameDescriptor.FRAME_ALIGNMENT;
+
+                while (offset >= gapOffset)
+                {
+                    if (0 != termBuffer.GetInt(offset))
+                    {
+                        return false;
+                    }
+
+                    offset -= FrameDescriptor.FRAME_ALIGNMENT;
+                }
+
+                LogBufferDescriptor.ApplyDefaultHeader(logMetaDataBuffer, termBuffer, gapOffset);
+                FrameDescriptor.FrameType(termBuffer, gapOffset, HeaderFlyweight.HDR_TYPE_PAD);
+                FrameDescriptor.FrameTermOffset(termBuffer, gapOffset);
+                FrameDescriptor.FrameTermId(termBuffer, gapOffset, termId);
+                FrameDescriptor.FrameLengthOrdered(termBuffer, gapOffset, gapLength);
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Adaptive.Aeron/LogBuffer/TermGapFiller.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermGapFiller.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.Protocol;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron.LogBuffer

--- a/src/Adaptive.Aeron/LogBuffer/TermReader.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermReader.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
 using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/LogBuffer/TermReader.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermReader.cs
@@ -46,6 +46,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="currentPosition">    prior to reading further fragments </param>
         /// <param name="subscriberPosition"> to be updated after reading with new position </param>
         /// <returns> the number of fragments read </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Read(UnsafeBuffer termBuffer, int termOffset, FragmentHandler handler, int fragmentsLimit, Header header, ErrorHandler errorHandler, long currentPosition, IPosition subscriberPosition)
         {
             int fragmentsRead = 0;

--- a/src/Adaptive.Aeron/LogBuffer/TermRebuilder.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermRebuilder.cs
@@ -10,21 +10,27 @@ namespace Adaptive.Aeron.LogBuffer
     public class TermRebuilder
     {
         /// <summary>
-        /// Insert a packet of frames into the log at the appropriate offset as indicated by the term termOffset header.
+        /// Insert a packet of frames into the log at the appropriate termOffset as indicated by the term termOffset header.
+        /// 
+        /// If the packet has already been inserted then this is a noop.
         /// </summary>
         /// <param name="termBuffer"> into which the packet should be inserted. </param>
-        /// <param name="termOffset">     offset in the term at which the packet should be inserted. </param>
+        /// <param name="termOffset"> in the term at which the packet should be inserted. </param>
         /// <param name="packet">     containing a sequence of frames. </param>
         /// <param name="length">     of the sequence of frames in bytes. </param>
         public static void Insert(IAtomicBuffer termBuffer, int termOffset, UnsafeBuffer packet, int length)
         {
-            termBuffer.PutBytes(termOffset + DataHeaderFlyweight.HEADER_LENGTH, packet, DataHeaderFlyweight.HEADER_LENGTH, length - DataHeaderFlyweight.HEADER_LENGTH);
+            if (0 == termBuffer.GetInt(termOffset))
+            {
+                termBuffer.PutBytes(termOffset + DataHeaderFlyweight.HEADER_LENGTH, packet,
+                    DataHeaderFlyweight.HEADER_LENGTH, length - DataHeaderFlyweight.HEADER_LENGTH);
 
-            termBuffer.PutLong(termOffset + 24, packet.GetLong(24));
-            termBuffer.PutLong(termOffset + 16, packet.GetLong(16));
-            termBuffer.PutLong(termOffset + 8, packet.GetLong(8));
+                termBuffer.PutLong(termOffset + 24, packet.GetLong(24));
+                termBuffer.PutLong(termOffset + 16, packet.GetLong(16));
+                termBuffer.PutLong(termOffset + 8, packet.GetLong(8));
 
-            termBuffer.PutLongOrdered(termOffset, packet.GetLong(0));
+                termBuffer.PutLongOrdered(termOffset, packet.GetLong(0));
+            }
         }
     }
 }

--- a/src/Adaptive.Aeron/LogBuffer/TermRebuilder.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermRebuilder.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Aeron.Protocol;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Aeron.Protocol;
 using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron.LogBuffer

--- a/src/Adaptive.Aeron/LogBuffers.cs
+++ b/src/Adaptive.Aeron/LogBuffers.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.IO;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;

--- a/src/Adaptive.Aeron/MappedLogBuffersFactory.cs
+++ b/src/Adaptive.Aeron/MappedLogBuffersFactory.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron
 {

--- a/src/Adaptive.Aeron/Properties/AssemblyInfo.cs
+++ b/src/Adaptive.Aeron/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Adaptive.Aeron/Protocol/DataHeaderFlyweight.cs
+++ b/src/Adaptive.Aeron/Protocol/DataHeaderFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Text;
 using Adaptive.Agrona.Concurrent;
 

--- a/src/Adaptive.Aeron/Protocol/HeaderFlyweight.cs
+++ b/src/Adaptive.Aeron/Protocol/HeaderFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using Adaptive.Agrona;
 using Adaptive.Agrona.Concurrent;
 

--- a/src/Adaptive.Aeron/Protocol/HeaderFlyweight.cs
+++ b/src/Adaptive.Aeron/Protocol/HeaderFlyweight.cs
@@ -46,6 +46,10 @@ namespace Adaptive.Aeron.Protocol
         public const int HDR_TYPE_SETUP = 0x05;
 
         /// <summary>
+        /// header type RTT Measurement </summary>
+        public const int HDR_TYPE_RTTM = 0x06;
+
+        /// <summary>
         /// header type EXT </summary>
         public const int HDR_TYPE_EXT = 0xFFFF;
 

--- a/src/Adaptive.Aeron/Protocol/RttMeasurementFlyweight.cs
+++ b/src/Adaptive.Aeron/Protocol/RttMeasurementFlyweight.cs
@@ -1,4 +1,20 @@
-﻿using System.Text;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
 using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron.Protocol

--- a/src/Adaptive.Aeron/Protocol/RttMeasurementFlyweight.cs
+++ b/src/Adaptive.Aeron/Protocol/RttMeasurementFlyweight.cs
@@ -1,0 +1,130 @@
+﻿using System.Text;
+using Adaptive.Agrona.Concurrent;
+
+namespace Adaptive.Aeron.Protocol
+{
+    /// <summary>
+    /// Flyweight for an RTT Measurement Packet
+    /// 
+    /// <a href="https://github.com/real-logic/Aeron/wiki/Protocol-Specification#rtt-measurement-header">
+    /// RTT Measurement Header</a>
+    /// </summary>
+    public class RttMeasurementFlyweight : HeaderFlyweight
+    {
+        public const short REPLY_FLAG = 0x80;
+        public const int HEADER_LENGTH = 40;
+
+        private const int SESSION_ID_FIELD_OFFSET = 8;
+        private const int STREAM_ID_FIELD_OFFSET = 12;
+        private const int ECHO_TIMESTAMP_FIELD_OFFSET = 16;
+        private const int RECEPTION_DELTA_FIELD_OFFSET = 24;
+        private const int RECEIVER_ID_FIELD_OFFSET = 32;
+
+        public RttMeasurementFlyweight()
+        {
+        }
+
+        public RttMeasurementFlyweight(UnsafeBuffer buffer) : base(buffer)
+        {
+        }
+
+        /// <summary>
+        /// return session id field
+        /// </summary>
+        /// <returns> session id field </returns>
+        public virtual int SessionId()
+        {
+            return GetInt(SESSION_ID_FIELD_OFFSET);
+        }
+
+        /// <summary>
+        /// set session id field
+        /// </summary>
+        /// <param name="sessionId"> field value </param>
+        /// <returns> flyweight </returns>
+        public virtual RttMeasurementFlyweight SessionId(int sessionId)
+        {
+            PutInt(SESSION_ID_FIELD_OFFSET, sessionId);
+
+            return this;
+        }
+
+        /// <summary>
+        /// return stream id field
+        /// </summary>
+        /// <returns> stream id field </returns>
+        public virtual int StreamId()
+        {
+            return GetInt(STREAM_ID_FIELD_OFFSET);
+        }
+
+        /// <summary>
+        /// set stream id field
+        /// </summary>
+        /// <param name="streamId"> field value </param>
+        /// <returns> flyweight </returns>
+        public virtual RttMeasurementFlyweight StreamId(int streamId)
+        {
+            PutInt(STREAM_ID_FIELD_OFFSET, streamId);
+
+            return this;
+        }
+
+        public virtual long EchoTimestamp()
+        {
+            return GetLong(ECHO_TIMESTAMP_FIELD_OFFSET);
+        }
+
+        public virtual RttMeasurementFlyweight EchoTimestamp(long timestamp)
+        {
+            PutLong(ECHO_TIMESTAMP_FIELD_OFFSET, timestamp);
+
+            return this;
+        }
+
+        public virtual long ReceptionDelta()
+        {
+            return GetLong(RECEPTION_DELTA_FIELD_OFFSET);
+        }
+
+        public virtual RttMeasurementFlyweight ReceptionDeltaFlyweight(long delta)
+        {
+            PutLong(RECEPTION_DELTA_FIELD_OFFSET, delta);
+
+            return this;
+        }
+
+        public virtual long ReceiverId()
+        {
+            return GetLong(RECEIVER_ID_FIELD_OFFSET);
+        }
+
+        public virtual RttMeasurementFlyweight ReceiverId(long id)
+        {
+            PutLong(RECEIVER_ID_FIELD_OFFSET, id);
+
+            return this;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            // TODO string formattedFlags = string.Format("{0,8}", Integer.toBinaryString(Flags())).Replace(' ', '0');
+            string formattedFlags = string.Empty;
+
+            sb.Append("RTT Measure Message{")
+                .Append("frame_length=").Append(FrameLength())
+                .Append(" version=").Append(Version())
+                .Append(" flags=").Append(formattedFlags)
+                .Append(" type=").Append(HeaderType())
+                .Append(" session_id=").Append(SessionId())
+                .Append(" stream_id=").Append(StreamId())
+                .Append(" echo_timestamp=").Append(EchoTimestamp())
+                .Append(" reception_delta=").Append(ReceptionDelta())
+                .Append(" receiver_id=").Append(ReceiverId()).Append("}");
+
+            return sb.ToString();
+        }
+
+}
+}

--- a/src/Adaptive.Aeron/Publication.cs
+++ b/src/Adaptive.Aeron/Publication.cs
@@ -11,7 +11,8 @@ namespace Adaptive.Aeron
 {
     /// <summary>
     /// Aeron Publisher API for sending messages to subscribers of a given channel and streamId pair. Publishers
-    /// are created via an <seealso cref="Aeron"/> object, and messages are sent via an offer method or a claim and commit
+    /// are created via the <seealso cref="Aeron.AddPublication(String, int)"/> method, and messages are sent via one of the
+    /// <seealso cref="Offer(DirectBuffer)"/> methods, or a <seealso cref="TryClaim(int, BufferClaim)"/> and <seealso cref="BufferClaim.Commit"/>
     /// method combination.
     /// <para>
     /// The APIs used to send are all non-blocking.
@@ -348,10 +349,7 @@ namespace Adaptive.Aeron
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void IncRef()
         {
-            lock (_clientConductor)
-            {
-                ++_refCount;
-            }
+            ++_refCount;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Adaptive.Aeron/Publication.cs
+++ b/src/Adaptive.Aeron/Publication.cs
@@ -436,7 +436,7 @@ namespace Adaptive.Aeron
         {
             if (length > MaxPayloadLength)
             {
-                throw new ArgumentException(
+                ThrowHelper.ThrowArgumentException(
                     $"Claim exceeds maxPayloadLength of {MaxPayloadLength:D}, length={length:D}");
             }
         }
@@ -446,7 +446,7 @@ namespace Adaptive.Aeron
         {
             if (length > MaxMessageLength)
             {
-                throw new ArgumentException(
+                ThrowHelper.ThrowArgumentException(
                     $"Mssage exceeds maxMessageLength of {MaxMessageLength:D}, length={length:D}");
             }
         }

--- a/src/Adaptive.Aeron/Publication.cs
+++ b/src/Adaptive.Aeron/Publication.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Protocol;

--- a/src/Adaptive.Aeron/ReservedValueSupplier.cs
+++ b/src/Adaptive.Aeron/ReservedValueSupplier.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona;
 
 namespace Adaptive.Aeron
 {

--- a/src/Adaptive.Aeron/Subscription.cs
+++ b/src/Adaptive.Aeron/Subscription.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0S
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Adaptive.Aeron.LogBuffer;

--- a/src/Adaptive.Aeron/Subscription.cs
+++ b/src/Adaptive.Aeron/Subscription.cs
@@ -44,25 +44,20 @@ namespace Adaptive.Aeron
 
     /// <summary>
     /// Aeron Subscriber API for receiving a reconstructed <seealso cref="Image"/> for a stream of messages from publishers on
-    /// a given channel and streamId pair.
-    /// <para>
-    /// Subscribers are created via an <seealso cref="Aeron"/> object, and received messages are delivered
+    /// a given channel and streamId pair. <seealso cref="Image"/>s are aggregated under a <seealso cref="Subscription"/>.
+    /// 
+    /// <seealso cref="Subscription"/>s are created via an <seealso cref="Aeron"/> object, and received messages are delivered
     /// to the <seealso cref="FragmentHandler"/>.
-    /// </para>
-    /// <para>
+    /// 
     /// By default fragmented messages are not reassembled before delivery. If an application must
     /// receive whole messages, whether or not they were fragmented, then the Subscriber
     /// should be created with a <seealso cref="FragmentAssembler"/> or a custom implementation.
-    /// </para>
-    /// <para>
-    /// It is an application's responsibility to <seealso cref="Poll"/> the Subscriber for new messages.
-    /// </para>
-    /// <para>
-    /// Subscriptions are not threadsafe and should not be shared between subscribers.
     /// 
-    /// </para>
+    /// It is an application's responsibility to <seealso cref="Poll"/> the <seealso cref="Subscription"/> for new messages.
+    /// 
+    /// <b>Note:</b>Subscriptions are not threadsafe and should not be shared between subscribers.
     /// </summary>
-    /// <seealso cref="FragmentAssembler" />
+    /// <seealso cref="FragmentAssembler"> </seealso>
     public class Subscription : IDisposable
     {
         private SubscriptionFields _fields;

--- a/src/Adaptive.Agrona.PerformanceTest/Adaptive.Agrona.PerformanceTest.csproj
+++ b/src/Adaptive.Agrona.PerformanceTest/Adaptive.Agrona.PerformanceTest.csproj
@@ -73,6 +73,9 @@
       <Name>Adaptive.Agrona</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Agrona.PerformanceTest.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Adaptive.Agrona.PerformanceTest/Adaptive.Agrona.PerformanceTest.licenseheader
+++ b/src/Adaptive.Agrona.PerformanceTest/Adaptive.Agrona.PerformanceTest.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Adaptive.Agrona.PerformanceTest/ManyToOneRingBufferConcurrentTest.cs
+++ b/src/Adaptive.Agrona.PerformanceTest/ManyToOneRingBufferConcurrentTest.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Concurrent.RingBuffer;

--- a/src/Adaptive.Agrona.PerformanceTest/Program.cs
+++ b/src/Adaptive.Agrona.PerformanceTest/Program.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 
 namespace Adaptive.Agrona.PerformanceTest

--- a/src/Adaptive.Agrona.PerformanceTest/Properties/AssemblyInfo.cs
+++ b/src/Adaptive.Agrona.PerformanceTest/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.csproj
+++ b/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Adaptive.Agrona.Tests.licenseheader" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.csproj
+++ b/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.csproj
@@ -50,12 +50,11 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy">
-      <HintPath>..\packages\FakeItEasy.2.0.0-rc2\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.4.2.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.4.2\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.licenseheader
+++ b/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Adaptive.Agrona.Tests/AtomicBufferTests.cs
+++ b/src/Adaptive.Agrona.Tests/AtomicBufferTests.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Adaptive.Agrona.Tests/BitUtilTest.cs
+++ b/src/Adaptive.Agrona.Tests/BitUtilTest.cs
@@ -1,4 +1,20 @@
-﻿using NUnit.Framework;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using NUnit.Framework;
 
 namespace Adaptive.Agrona.Tests
 {

--- a/src/Adaptive.Agrona.Tests/Collections/ArrayUtilTests.cs
+++ b/src/Adaptive.Agrona.Tests/Collections/ArrayUtilTests.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona.Collections;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona.Collections;
 using NUnit.Framework;
 
 namespace Adaptive.Agrona.Tests.Collections

--- a/src/Adaptive.Agrona.Tests/Collections/CollectionUtilTests.cs
+++ b/src/Adaptive.Agrona.Tests/Collections/CollectionUtilTests.cs
@@ -1,4 +1,20 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
 using Adaptive.Agrona.Collections;
 using NUnit.Framework;
 

--- a/src/Adaptive.Agrona.Tests/Concurrent/Broadcast/BroadcastReceiverTest.cs
+++ b/src/Adaptive.Agrona.Tests/Concurrent/Broadcast/BroadcastReceiverTest.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Concurrent.Broadcast;
 using FakeItEasy;

--- a/src/Adaptive.Agrona.Tests/Concurrent/CountersManagerTest.cs
+++ b/src/Adaptive.Agrona.Tests/Concurrent/CountersManagerTest.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Agrona.Collections;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Concurrent.Status;

--- a/src/Adaptive.Agrona.Tests/Concurrent/RingBuffer/ManyToOneRingBufferTest.cs
+++ b/src/Adaptive.Agrona.Tests/Concurrent/RingBuffer/ManyToOneRingBufferTest.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Agrona.Concurrent;
 using Adaptive.Agrona.Concurrent.RingBuffer;
 using FakeItEasy;

--- a/src/Adaptive.Agrona.Tests/EndianessConverterTests.cs
+++ b/src/Adaptive.Agrona.Tests/EndianessConverterTests.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Linq;
 using NUnit.Framework;
 

--- a/src/Adaptive.Agrona.Tests/ExpectedException.cs
+++ b/src/Adaptive.Agrona.Tests/ExpectedException.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;

--- a/src/Adaptive.Agrona.Tests/Properties/AssemblyInfo.cs
+++ b/src/Adaptive.Agrona.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Adaptive.Agrona.Tests/packages.config
+++ b/src/Adaptive.Agrona.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.0.0-rc2" targetFramework="net452" />
-  <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.4.2" targetFramework="net452" />
+  <package id="NUnit" version="3.7.1" targetFramework="net452" />
 </packages>

--- a/src/Adaptive.Agrona/Adaptive.Agrona.csproj
+++ b/src/Adaptive.Agrona/Adaptive.Agrona.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Util\LockSupport.cs" />
     <Compile Include="Util\MappedByteBuffer.cs" />
     <Compile Include="Util\NanoUtil.cs" />
+    <Compile Include="Util\ThrowHelper.cs" />
     <Compile Include="Util\UnixTimeConverter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Adaptive.Agrona/Adaptive.Agrona.csproj
+++ b/src/Adaptive.Agrona/Adaptive.Agrona.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ByteBuffer.cs" />
+    <Compile Include="CacheLinePadding.cs" />
     <Compile Include="Concurrent\AtomicBoolean.cs" />
     <Compile Include="Concurrent\AtomicLong.cs" />
     <Compile Include="BitUtil.cs" />
@@ -124,6 +125,7 @@
     <Compile Include="Concurrent\SystemEpochClock.cs" />
     <Compile Include="Util\ByteUtil.cs" />
     <Compile Include="Util\IntUtil.cs" />
+    <Compile Include="Util\LockSupport.cs" />
     <Compile Include="Util\MappedByteBuffer.cs" />
     <Compile Include="Util\NanoUtil.cs" />
     <Compile Include="Util\UnixTimeConverter.cs" />

--- a/src/Adaptive.Agrona/Adaptive.Agrona.csproj
+++ b/src/Adaptive.Agrona/Adaptive.Agrona.csproj
@@ -130,6 +130,9 @@
     <Compile Include="Util\NanoUtil.cs" />
     <Compile Include="Util\UnixTimeConverter.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Agrona.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Adaptive.Agrona/Adaptive.Agrona.licenseheader
+++ b/src/Adaptive.Agrona/Adaptive.Agrona.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Adaptive.Agrona/BitUtil.cs
+++ b/src/Adaptive.Agrona/BitUtil.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Adaptive.Agrona.Util;

--- a/src/Adaptive.Agrona/BitUtil.cs
+++ b/src/Adaptive.Agrona/BitUtil.cs
@@ -300,7 +300,7 @@ namespace Adaptive.Agrona
         {
             if (!IsPowerOfTwo(alignment))
             {
-                throw new ArgumentException("Alignment must be a power of 2: alignment=" + alignment);
+                ThrowHelper.ThrowArgumentException("Alignment must be a power of 2: alignment=" + alignment);
             }
 
             return (address & (alignment - 1)) == 0;

--- a/src/Adaptive.Agrona/BufferUtil.cs
+++ b/src/Adaptive.Agrona/BufferUtil.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Text;
 
 namespace Adaptive.Agrona

--- a/src/Adaptive.Agrona/BufferUtil.cs
+++ b/src/Adaptive.Agrona/BufferUtil.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using Adaptive.Agrona.Util;
 using System;
 using System.Text;
 
@@ -39,7 +40,7 @@ namespace Adaptive.Agrona
             var resultingPosition = index + length;
             if (index < 0 || resultingPosition > capacity)
             {
-                throw new IndexOutOfRangeException($"index={index:D}, length={length:D}, capacity={capacity:D}");
+                ThrowHelper.ThrowIndexOutOfRangeException($"index={index:D}, length={length:D}, capacity={capacity:D}");
             }
 #endif
         }

--- a/src/Adaptive.Agrona/ByteBuffer.cs
+++ b/src/Adaptive.Agrona/ByteBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.InteropServices;
 
 namespace Adaptive.Agrona

--- a/src/Adaptive.Agrona/ByteOrder.cs
+++ b/src/Adaptive.Agrona/ByteOrder.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona
 {
     public enum ByteOrder
     {

--- a/src/Adaptive.Agrona/CacheLinePadding.cs
+++ b/src/Adaptive.Agrona/CacheLinePadding.cs
@@ -1,0 +1,13 @@
+﻿namespace Adaptive.Agrona
+{
+    public struct CacheLinePadding
+    {
+        private long p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15;
+
+        // To prevent compiler removing unused padding fields
+        public override string ToString()
+        {
+            return $"{nameof(p1)}: {p1}, {nameof(p2)}: {p2}, {nameof(p3)}: {p3}, {nameof(p4)}: {p4}, {nameof(p5)}: {p5}, {nameof(p6)}: {p6}, {nameof(p7)}: {p7}, {nameof(p8)}: {p8}, {nameof(p9)}: {p9}, {nameof(p10)}: {p10}, {nameof(p11)}: {p11}, {nameof(p12)}: {p12}, {nameof(p13)}: {p13}, {nameof(p14)}: {p14}, {nameof(p15)}: {p15}";
+        }
+    }
+}

--- a/src/Adaptive.Agrona/CacheLinePadding.cs
+++ b/src/Adaptive.Agrona/CacheLinePadding.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona
 {
     public struct CacheLinePadding
     {

--- a/src/Adaptive.Agrona/CloseHelper.cs
+++ b/src/Adaptive.Agrona/CloseHelper.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona
 {

--- a/src/Adaptive.Agrona/Collections/ArrayUtil.cs
+++ b/src/Adaptive.Agrona/Collections/ArrayUtil.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Collections
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Collections
 {
     using System;
 

--- a/src/Adaptive.Agrona/Collections/CollectionUtil.cs
+++ b/src/Adaptive.Agrona/Collections/CollectionUtil.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 
 namespace Adaptive.Agrona.Collections

--- a/src/Adaptive.Agrona/Collections/IntObjConsumer.cs
+++ b/src/Adaptive.Agrona/Collections/IntObjConsumer.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Collections
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Collections
 {
 	/// <summary>
 	/// This is an (int, Object) primitive specialisation of a BiConsumer.

--- a/src/Adaptive.Agrona/Concurrent/AgentRunner.cs
+++ b/src/Adaptive.Agrona/Concurrent/AgentRunner.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 using Adaptive.Agrona.Concurrent.Status;
 

--- a/src/Adaptive.Agrona/Concurrent/AtomicBoolean.cs
+++ b/src/Adaptive.Agrona/Concurrent/AtomicBoolean.cs
@@ -15,7 +15,9 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using Adaptive.Agrona.Util;
 
 namespace Adaptive.Agrona.Concurrent
 {
@@ -37,6 +39,7 @@ namespace Adaptive.Agrona.Concurrent
         /// <param name="newValue">The new value</param>
         /// <param name="comparand">The comparand (expected value)</param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool CompareAndSet(bool comparand, bool newValue)
         {
             var newValueInt = ToInt(newValue);
@@ -45,26 +48,30 @@ namespace Adaptive.Agrona.Concurrent
             return Interlocked.CompareExchange(ref _value, newValueInt, comparandInt) == comparandInt;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Get()
         {
             return ToBool(Volatile.Read(ref _value));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ToBool(int value)
         {
             if (value != FALSE && value != TRUE)
             {
-                throw new ArgumentOutOfRangeException(nameof(value));
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(value));
             }
 
             return value == TRUE;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ToInt(bool value)
         {
             return value ? TRUE : FALSE;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(bool value)
         {
             Volatile.Write(ref _value, ToInt(value));

--- a/src/Adaptive.Agrona/Concurrent/AtomicBoolean.cs
+++ b/src/Adaptive.Agrona/Concurrent/AtomicBoolean.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent

--- a/src/Adaptive.Agrona/Concurrent/AtomicLong.cs
+++ b/src/Adaptive.Agrona/Concurrent/AtomicLong.cs
@@ -1,4 +1,20 @@
-﻿using System.Threading;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/AtomicReference.cs
+++ b/src/Adaptive.Agrona/Concurrent/AtomicReference.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent

--- a/src/Adaptive.Agrona/Concurrent/Broadcast/BroadcastBufferDescriptor.cs
+++ b/src/Adaptive.Agrona/Concurrent/Broadcast/BroadcastBufferDescriptor.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using Adaptive.Agrona.Util;
 using System;
 
 namespace Adaptive.Agrona.Concurrent.Broadcast
@@ -68,7 +69,7 @@ namespace Adaptive.Agrona.Concurrent.Broadcast
             if (!BitUtil.IsPowerOfTwo(capacity))
             {
                 var msg = "Capacity must be a positive power of 2 + TRAILER_LENGTH: capacity=" + capacity;
-                throw new InvalidOperationException(msg);
+                ThrowHelper.ThrowInvalidOperationException(msg);
             }
         }
     }

--- a/src/Adaptive.Agrona/Concurrent/Broadcast/BroadcastBufferDescriptor.cs
+++ b/src/Adaptive.Agrona/Concurrent/Broadcast/BroadcastBufferDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.Broadcast
 {

--- a/src/Adaptive.Agrona/Concurrent/Broadcast/BroadcastReceiver.cs
+++ b/src/Adaptive.Agrona/Concurrent/Broadcast/BroadcastReceiver.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent.Broadcast

--- a/src/Adaptive.Agrona/Concurrent/Broadcast/CopyBroadcastReceiver.cs
+++ b/src/Adaptive.Agrona/Concurrent/Broadcast/CopyBroadcastReceiver.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.Broadcast
 {

--- a/src/Adaptive.Agrona/Concurrent/Broadcast/RecordDescriptor.cs
+++ b/src/Adaptive.Agrona/Concurrent/Broadcast/RecordDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.Broadcast
 {

--- a/src/Adaptive.Agrona/Concurrent/BusySpinIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/BusySpinIdleStrategy.cs
@@ -1,4 +1,20 @@
-﻿using System.Threading;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/DefaultThreadFactory.cs
+++ b/src/Adaptive.Agrona/Concurrent/DefaultThreadFactory.cs
@@ -1,4 +1,20 @@
-﻿using System.Threading;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/Errors/DistinctErrorLog.cs
+++ b/src/Adaptive.Agrona/Concurrent/Errors/DistinctErrorLog.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Text;
 
 namespace Adaptive.Agrona.Concurrent.Errors

--- a/src/Adaptive.Agrona/Concurrent/Errors/ErrorReader.cs
+++ b/src/Adaptive.Agrona/Concurrent/Errors/ErrorReader.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent.Errors
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent.Errors
 {
     /// <summary>
     /// Reader for the log created by a <seealso cref="DistinctErrorLog"/>.

--- a/src/Adaptive.Agrona/Concurrent/Errors/IErrorConsumer.cs
+++ b/src/Adaptive.Agrona/Concurrent/Errors/IErrorConsumer.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent.Errors
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent.Errors
 {
     public delegate void ErrorConsumer(int observationCount, long firstObservationTimestamp, long lastObservationTimestamp, string encodedException);
 }

--- a/src/Adaptive.Agrona/Concurrent/IAgent.cs
+++ b/src/Adaptive.Agrona/Concurrent/IAgent.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/IAtomicBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/IAtomicBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/IEpochClock.cs
+++ b/src/Adaptive.Agrona/Concurrent/IEpochClock.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent
 {
     /// <summary>
     /// Retrieves the number of milliseconds since 1 Jan 1970 UTC.

--- a/src/Adaptive.Agrona/Concurrent/IIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/IIdleStrategy.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent
 {
 
     /// <summary>

--- a/src/Adaptive.Agrona/Concurrent/INanoClock.cs
+++ b/src/Adaptive.Agrona/Concurrent/INanoClock.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent
 {
 
     /// <summary>

--- a/src/Adaptive.Agrona/Concurrent/IThreadFactory.cs
+++ b/src/Adaptive.Agrona/Concurrent/IThreadFactory.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent

--- a/src/Adaptive.Agrona/Concurrent/MessageHandler.cs
+++ b/src/Adaptive.Agrona/Concurrent/MessageHandler.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent
 {
     /// <summary>
     /// Callback interface for processing of messages that are read from a buffer.

--- a/src/Adaptive.Agrona/Concurrent/NoOpIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/NoOpIdleStrategy.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent
 {
     /// <summary>
     /// Low-latency idle strategy to be employed in loops that do significant work on each iteration such that any work in the

--- a/src/Adaptive.Agrona/Concurrent/RingBuffer/IRingBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/RingBuffer/IRingBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.RingBuffer
 {

--- a/src/Adaptive.Agrona/Concurrent/RingBuffer/ManyToOneRingBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/RingBuffer/ManyToOneRingBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent.RingBuffer

--- a/src/Adaptive.Agrona/Concurrent/RingBuffer/RecordDescriptor.cs
+++ b/src/Adaptive.Agrona/Concurrent/RingBuffer/RecordDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.RingBuffer
 {

--- a/src/Adaptive.Agrona/Concurrent/RingBuffer/RingBufferDescriptor.cs
+++ b/src/Adaptive.Agrona/Concurrent/RingBuffer/RingBufferDescriptor.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.RingBuffer
 {

--- a/src/Adaptive.Agrona/Concurrent/RingBuffer/RingBufferDescriptor.cs
+++ b/src/Adaptive.Agrona/Concurrent/RingBuffer/RingBufferDescriptor.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using Adaptive.Agrona.Util;
 
 namespace Adaptive.Agrona.Concurrent.RingBuffer
 {
@@ -87,7 +88,7 @@ namespace Adaptive.Agrona.Concurrent.RingBuffer
             if (!BitUtil.IsPowerOfTwo(capacity - TrailerLength))
             {
                 var msg = "Capacity must be a positive power of 2 + TRAILER_LENGTH: capacity=" + capacity;
-                throw new InvalidOperationException(msg);
+                ThrowHelper.ThrowInvalidOperationException(msg);
             }
         }
     }

--- a/src/Adaptive.Agrona/Concurrent/SleepingIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/SleepingIdleStrategy.cs
@@ -1,4 +1,20 @@
-﻿using System.Threading;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/SpinWaitIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/SpinWaitIdleStrategy.cs
@@ -1,4 +1,20 @@
-﻿using System.Threading;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/Status/AtomicCounter.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/AtomicCounter.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.Status
 {

--- a/src/Adaptive.Agrona/Concurrent/Status/AtomicLongPosition.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/AtomicLongPosition.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 
 namespace Adaptive.Agrona.Concurrent.Status
 {

--- a/src/Adaptive.Agrona/Concurrent/Status/CountersManager.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersManager.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 
 namespace Adaptive.Agrona.Concurrent.Status

--- a/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
@@ -1,4 +1,20 @@
-﻿using Adaptive.Agrona.Collections;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Adaptive.Agrona.Collections;
 
 namespace Adaptive.Agrona.Concurrent.Status
 {

--- a/src/Adaptive.Agrona/Concurrent/Status/IPosition.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/IPosition.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Concurrent.Status
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Concurrent.Status
 {
     /// <summary>
     /// Reports on how far through a buffer some component has progressed.

--- a/src/Adaptive.Agrona/Concurrent/Status/IReadablePosition.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/IReadablePosition.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Concurrent.Status
 {

--- a/src/Adaptive.Agrona/Concurrent/Status/UnsafeBufferPosition.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/UnsafeBufferPosition.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 
 namespace Adaptive.Agrona.Concurrent.Status
 {

--- a/src/Adaptive.Agrona/Concurrent/Status/UnsafeBufferPosition.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/UnsafeBufferPosition.cs
@@ -63,7 +63,11 @@ namespace Adaptive.Agrona.Concurrent.Status
             return _buffer.GetLong(_offset);
         }
 
-        public long Volatile => _buffer.GetLongVolatile(_offset);
+        public long Volatile
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _buffer.GetLongVolatile(_offset); }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(long value)

--- a/src/Adaptive.Agrona/Concurrent/StopwatchClock.cs
+++ b/src/Adaptive.Agrona/Concurrent/StopwatchClock.cs
@@ -1,4 +1,20 @@
-﻿using System.Diagnostics;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Diagnostics;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/SystemEpochClock.cs
+++ b/src/Adaptive.Agrona/Concurrent/SystemEpochClock.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Agrona.Util;
 
 namespace Adaptive.Agrona.Concurrent

--- a/src/Adaptive.Agrona/Concurrent/SystemEpochClock.cs
+++ b/src/Adaptive.Agrona/Concurrent/SystemEpochClock.cs
@@ -15,12 +15,14 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using Adaptive.Agrona.Util;
 
 namespace Adaptive.Agrona.Concurrent
 {
     public class SystemEpochClock : IEpochClock
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long Time()
         {
             return UnixTimeConverter.CurrentUnixTimeMillis();

--- a/src/Adaptive.Agrona/Concurrent/SystemNanoClock.cs
+++ b/src/Adaptive.Agrona/Concurrent/SystemNanoClock.cs
@@ -1,4 +1,20 @@
-﻿using System.Diagnostics;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Diagnostics;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
@@ -130,7 +130,10 @@ namespace Adaptive.Agrona.Concurrent
         public void Wrap(byte[] buffer)
 #endif
         {
-            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (buffer == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(buffer));
+            }
 
             FreeGcHandle();
 
@@ -148,18 +151,21 @@ namespace Adaptive.Agrona.Concurrent
         public void Wrap(byte[] buffer, int offset, int length)
 #endif
         {
-            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (buffer == null)
+            {
+                ThrowHelper.ThrowArgumentException(nameof(buffer));
+            }
 
 #if SHOULD_BOUNDS_CHECK
             int bufferLength = buffer.Length;
             if (offset != 0 && (offset < 0 || offset > bufferLength - 1))
             {
-                throw new ArgumentException("offset=" + offset + " not valid for buffer.length=" + bufferLength);
+                ThrowHelper.ThrowArgumentException("offset=" + offset + " not valid for buffer.length=" + bufferLength);
             }
 
             if (length < 0 || length > bufferLength - offset)
             {
-                throw new ArgumentException("offset=" + offset + " length=" + length + " not valid for buffer.length=" + bufferLength);
+                ThrowHelper.ThrowArgumentException("offset=" + offset + " length=" + length + " not valid for buffer.length=" + bufferLength);
             }
 #endif
 
@@ -209,12 +215,12 @@ namespace Adaptive.Agrona.Concurrent
             int bufferCapacity = buffer.Capacity;
             if (offset != 0 && (offset < 0 || offset > bufferCapacity - 1))
             {
-                throw new ArgumentException("offset=" + offset + " not valid for buffer.capacity()=" + bufferCapacity);
+                ThrowHelper.ThrowArgumentException("offset=" + offset + " not valid for buffer.capacity()=" + bufferCapacity);
             }
 
             if (length < 0 || length > bufferCapacity - offset)
             {
-                throw new ArgumentException("offset=" + offset + " length=" + length + " not valid for buffer.capacity()=" + bufferCapacity);
+                ThrowHelper.ThrowArgumentException("offset=" + offset + " length=" + length + " not valid for buffer.capacity()=" + bufferCapacity);
             }
 #endif
 
@@ -256,7 +262,12 @@ namespace Adaptive.Agrona.Concurrent
 #if DEBUG
         public virtual IntPtr BufferPointer => new IntPtr(_pBuffer);
 #else
-        public IntPtr BufferPointer => new IntPtr(_pBuffer);
+        public IntPtr BufferPointer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return new IntPtr(_pBuffer); }
+        }
+
 #endif
 
 #if DEBUG
@@ -273,7 +284,6 @@ namespace Adaptive.Agrona.Concurrent
 #endif
         {
             BoundsCheck0(index, length);
-
             // TODO PERF Naive implementation, we should not write byte by byte, this is slow
             //UNSAFE.SetMemory(byteArray, addressOffset + index, length, value);
             for (var i = index; i < index + length; i++)
@@ -291,7 +301,7 @@ namespace Adaptive.Agrona.Concurrent
         {
             if (limit > Capacity)
             {
-                throw new IndexOutOfRangeException($"limit={limit:D} is beyond capacity={Capacity:D}");
+                ThrowHelper.ThrowIndexOutOfRangeException($"limit={limit:D} is beyond capacity={Capacity:D}");
             }
         }
 
@@ -307,7 +317,7 @@ namespace Adaptive.Agrona.Concurrent
             var address = new IntPtr(_pBuffer).ToInt64();
             if (0 != (address & (ALIGNMENT - 1)))
             {
-                throw new InvalidOperationException(
+                ThrowHelper.ThrowInvalidOperationException(
                     $"AtomicBuffer is not correctly aligned: addressOffset={address:D} in not divisible by {ALIGNMENT:D}");
             }
         }
@@ -360,8 +370,9 @@ namespace Adaptive.Agrona.Concurrent
         public long GetLongVolatile(int index)
 #endif
         {
+#if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
-
+#endif
             return Volatile.Read(ref *(long*) (_pBuffer + index));
         }
 
@@ -482,8 +493,9 @@ namespace Adaptive.Agrona.Concurrent
         public int GetIntVolatile(int index)
 #endif
         {
+#if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
-
+#endif
             return Volatile.Read(ref *(int*) (_pBuffer + index));
         }
 
@@ -506,8 +518,9 @@ namespace Adaptive.Agrona.Concurrent
         public void PutIntOrdered(int index, int value)
 #endif
         {
+#if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
-
+#endif
             Volatile.Write(ref *(int*) (_pBuffer + index), value);
         }
 
@@ -655,8 +668,9 @@ namespace Adaptive.Agrona.Concurrent
         public short GetShort(int index)
 #endif
         {
+#if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
-
+#endif
             return *(short*) (_pBuffer + index);
         }
 
@@ -943,7 +957,7 @@ namespace Adaptive.Agrona.Concurrent
                 : Encoding.UTF8.GetBytes(value);
             if (bytes.Length > maxEncodedSize)
             {
-                throw new ArgumentException("Encoded string larger than maximum size: " + maxEncodedSize);
+                ThrowHelper.ThrowArgumentException("Encoded string larger than maximum size: " + maxEncodedSize);
             }
 
             PutInt(index, bytes.Length);
@@ -960,7 +974,7 @@ namespace Adaptive.Agrona.Concurrent
                 : Encoding.ASCII.GetBytes(value);
             if (bytes.Length > maxEncodedSize)
             {
-                throw new ArgumentException("Encoded string larger than maximum size: " + maxEncodedSize);
+                ThrowHelper.ThrowArgumentException("Encoded string larger than maximum size: " + maxEncodedSize);
             }
 
             PutInt(index, bytes.Length);
@@ -1000,12 +1014,12 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private  void BoundsCheck(int index)
+        private void BoundsCheck(int index)
         {
 #if SHOULD_BOUNDS_CHECK
             if (index < 0 || index >= Capacity)
             {
-                throw new IndexOutOfRangeException($"index={index:D}, capacity={Capacity:D}");
+                ThrowHelper.ThrowIndexOutOfRangeException($"index={index:D}, capacity={Capacity:D}");
             }
 #endif
         }
@@ -1017,7 +1031,7 @@ namespace Adaptive.Agrona.Concurrent
             long resultingPosition = index + (long)length;
             if (index < 0 || resultingPosition > Capacity)
             {
-                throw new IndexOutOfRangeException($"index={index:D}, length={length:D}, capacity={Capacity:D}");
+            ThrowHelper.ThrowIndexOutOfRangeException($"index={index:D}, length={length:D}, capacity={Capacity:D}");
             }
 #endif
         }

--- a/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Adaptive.Agrona/Concurrent/YieldingIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/YieldingIdleStrategy.cs
@@ -1,4 +1,20 @@
-﻿using System.Threading;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
 
 namespace Adaptive.Agrona.Concurrent
 {

--- a/src/Adaptive.Agrona/EndianessConverter.cs
+++ b/src/Adaptive.Agrona/EndianessConverter.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Net;
 
 namespace Adaptive.Agrona

--- a/src/Adaptive.Agrona/ErrorHandler.cs
+++ b/src/Adaptive.Agrona/ErrorHandler.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona
 {

--- a/src/Adaptive.Agrona/IDirectBuffer.cs
+++ b/src/Adaptive.Agrona/IDirectBuffer.cs
@@ -201,6 +201,13 @@ namespace Adaptive.Agrona
         /// <returns> the String as represented by the UTF-8 encoded bytes. </returns>
         string GetStringUtf8(int index);
 
+        /// <summary>
+        /// Get a String from bytes encoded in ASCII format that is length prefixed.
+        /// </summary>
+        /// <param name="index">    at which the String begins. </param>
+        /// <returns> the String as represented by the ASCII encoded bytes. </returns>
+        string GetStringAscii(int index);
+
         ///// <summary>
         ///// Get a String from bytes encoded in UTF-8 format that is length prefixed.
         ///// </summary>
@@ -216,6 +223,14 @@ namespace Adaptive.Agrona
         /// <param name="length"> of the String in bytes to decode. </param>
         /// <returns> the String as represented by the UTF-8 encoded bytes. </returns>
         string GetStringUtf8(int index, int length);
+
+        /// <summary>
+        /// Get part of String from bytes encoded in ASCII format that is length prefixed.
+        /// </summary>
+        /// <param name="index"> at which the String begins. </param>
+        /// <param name="length"> of the String in bytes to decode. </param>
+        /// <returns> the String as represented by the ASCII encoded bytes. </returns>
+        string GetStringAscii(int index, int length);
 
         /// <summary>
         /// Get an encoded UTF-8 String from the buffer that does not have a length prefix.

--- a/src/Adaptive.Agrona/IDirectBuffer.cs
+++ b/src/Adaptive.Agrona/IDirectBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona
 {

--- a/src/Adaptive.Agrona/IManagedResource.cs
+++ b/src/Adaptive.Agrona/IManagedResource.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona
 {
 	/// <summary>
 	/// Implementations of this interface can a resource that need to have external state tracked for deletion.

--- a/src/Adaptive.Agrona/IMutableDirectBuffer.cs
+++ b/src/Adaptive.Agrona/IMutableDirectBuffer.cs
@@ -151,6 +151,14 @@ namespace Adaptive.Agrona
         /// <returns> the number of bytes put to the buffer. </returns>
         int PutStringUtf8(int index, string value);
 
+        /// <summary>
+        /// Encode a String as ASCII bytes to the buffer with a length prefix.
+        /// </summary>
+        /// <param name="index"> at which the String should be encoded. </param>
+        /// <param name="value">  of the String to be encoded. </param>
+        /// <returns> the number of bytes put to the buffer. </returns>
+        int PutStringAscii(int index, string value);
+
         ///// <summary>
         ///// Encode a String as UTF-8 bytes to the buffer with a length prefix.
         ///// </summary>

--- a/src/Adaptive.Agrona/IMutableDirectBuffer.cs
+++ b/src/Adaptive.Agrona/IMutableDirectBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona
 {

--- a/src/Adaptive.Agrona/IoUtil.cs
+++ b/src/Adaptive.Agrona/IoUtil.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using Adaptive.Agrona.Util;

--- a/src/Adaptive.Agrona/IoUtil.cs
+++ b/src/Adaptive.Agrona/IoUtil.cs
@@ -62,12 +62,44 @@ namespace Adaptive.Agrona
         }
 
         /// <summary>
+        /// Check that file exists, open file, and return MappedByteBuffer for entire file
+        /// <para>
+        /// The file itself will be closed, but the mapping will persist.
+        /// 
+        /// </para>
+        /// </summary>
+        /// <param name="location">         of the file to map </param>
+        /// <param name="descriptionLabel"> to be associated for any exceptions </param>
+        /// <returns> <seealso cref="MappedByteBuffer"/> for the file </returns>
+        public static MappedByteBuffer MapExistingFile(FileInfo location, string descriptionLabel)
+        {
+            CheckFileExists(location, descriptionLabel);
+
+            return new MappedByteBuffer(OpenMemoryMappedFile(location.FullName, MapMode.ReadWrite));
+        }
+
+
+        /// <summary>
         /// Unmap a <seealso cref="MappedByteBuffer"/> without waiting for the next GC cycle.
         /// </summary>
         /// <param name="wrapper"> to be unmapped. </param>
         public static void Unmap(MappedByteBuffer wrapper)
         {
             wrapper?.Dispose();
+        }
+
+        /// <summary>
+        /// Check that a file exists and throw an exception if not.
+        /// </summary>
+        /// <param name="file"> to check existence of. </param>
+        /// <param name="name"> to associate for the exception </param>
+        public static void CheckFileExists(FileInfo file, string name)
+        {
+            if (!file.Exists)
+            {
+                string msg = "Missing file for " + name + " : " + file.FullName;
+                throw new InvalidOperationException(msg);
+            }
         }
 
         /// <summary>
@@ -90,6 +122,11 @@ namespace Adaptive.Agrona
         public static string TmpDirName()
         {
             return Path.GetTempPath();
+        }
+
+        public static void Delete(FileSystemInfo file, bool b)
+        {   
+            file.Delete();
         }
     }
 }

--- a/src/Adaptive.Agrona/Properties/AssemblyInfo.cs
+++ b/src/Adaptive.Agrona/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Adaptive.Agrona/Util/ByteUtil.cs
+++ b/src/Adaptive.Agrona/Util/ByteUtil.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 namespace Adaptive.Agrona.Util {
 

--- a/src/Adaptive.Agrona/Util/ByteUtil.cs
+++ b/src/Adaptive.Agrona/Util/ByteUtil.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 namespace Adaptive.Agrona.Util {
 

--- a/src/Adaptive.Agrona/Util/IntUtil.cs
+++ b/src/Adaptive.Agrona/Util/IntUtil.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 
 namespace Adaptive.Agrona.Util
 {

--- a/src/Adaptive.Agrona/Util/LockSupport.cs
+++ b/src/Adaptive.Agrona/Util/LockSupport.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Adaptive.Agrona.Util

--- a/src/Adaptive.Agrona/Util/LockSupport.cs
+++ b/src/Adaptive.Agrona/Util/LockSupport.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Adaptive.Agrona.Util
+{
+    /// <summary>
+    /// Mimic Java class LockSupport
+    /// </summary>
+    public static class LockSupport
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ParkNanos(int nanos)
+        {
+            // TODO check closest equivalent in .NET
+            Thread.Sleep(1);
+        }
+    }
+}

--- a/src/Adaptive.Agrona/Util/MappedByteBuffer.cs
+++ b/src/Adaptive.Agrona/Util/MappedByteBuffer.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.IO.MemoryMappedFiles;
 
 namespace Adaptive.Agrona.Util

--- a/src/Adaptive.Agrona/Util/NanoUtil.cs
+++ b/src/Adaptive.Agrona/Util/NanoUtil.cs
@@ -1,4 +1,20 @@
-﻿namespace Adaptive.Agrona.Util
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Adaptive.Agrona.Util
 {
     public static class NanoUtil
     {

--- a/src/Adaptive.Agrona/Util/ThrowHelper.cs
+++ b/src/Adaptive.Agrona/Util/ThrowHelper.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Adaptive.Agrona.Util
+{
+    public static class ThrowHelper
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentException()
+        {
+            throw GetArgumentException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentException(string message)
+        {
+            throw GetArgumentException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException()
+        {
+            throw GetArgumentOutOfRangeException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException(string argument)
+        {
+            throw GetArgumentOutOfRangeException(argument);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowIndexOutOfRangeException(string message)
+        {
+            throw GetIndexOutOfRangeException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException()
+        {
+            throw GetInvalidOperationException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidCastException()
+        {
+            throw GetInvalidCastException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException(string message)
+        {
+            throw GetInvalidOperationException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ForVariantTypeMissmatch()
+        {
+            throw GetInvalidOperationException_ForVariantTypeMissmatch();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowNotImplementedException()
+        {
+            throw GetNotImplementedException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowNotImplementedException(string message)
+        {
+            throw GetNotImplementedException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowNotSupportedException()
+        {
+            throw GetNotSupportedException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowKeyNotFoundException(string message)
+        {
+            throw GetKeyNotFoundException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentNullException(string argument)
+        {
+            throw new ArgumentNullException(argument);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowObjectDisposedException(string objectName)
+        {
+            throw GetObjectDisposedException(objectName);
+        }
+
+        /////////////////////////////////////////////////////////////////////////////
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException()
+        {
+            return new ArgumentException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException(string message)
+        {
+            return new ArgumentException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+        {
+            return new ArgumentOutOfRangeException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(string argument)
+        {
+            return new ArgumentOutOfRangeException(argument);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static IndexOutOfRangeException GetIndexOutOfRangeException(string message)
+        {
+            return new IndexOutOfRangeException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException()
+        {
+            return new InvalidOperationException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidCastException GetInvalidCastException()
+        {
+            return new InvalidCastException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException(string message)
+        {
+            return new InvalidOperationException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException_ForVariantTypeMissmatch()
+        {
+            return new InvalidOperationException("Variant type doesn't match typeof(T)");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static NotImplementedException GetNotImplementedException()
+        {
+            return new NotImplementedException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static NotImplementedException GetNotImplementedException(string message)
+        {
+            return new NotImplementedException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static NotSupportedException GetNotSupportedException()
+        {
+            return new NotSupportedException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static KeyNotFoundException GetKeyNotFoundException(string message)
+        {
+            return new KeyNotFoundException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectDisposedException GetObjectDisposedException(string objectName)
+        {
+            return new ObjectDisposedException(objectName);
+        }
+    }
+}

--- a/src/Adaptive.Agrona/Util/UnixTimeConverter.cs
+++ b/src/Adaptive.Agrona/Util/UnixTimeConverter.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Adaptive.Agrona.Util
 {

--- a/src/Adaptive.Agrona/Util/UnixTimeConverter.cs
+++ b/src/Adaptive.Agrona/Util/UnixTimeConverter.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Adaptive.Agrona.Util
 {
@@ -22,11 +23,13 @@ namespace Adaptive.Agrona.Util
     {
         private static readonly DateTime Jan1st1970 = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long CurrentUnixTimeMillis()
         {
             return (long)(DateTime.UtcNow - Jan1st1970).TotalMilliseconds;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime FromUnixTimeMillis(long epoch)
         {
             return Jan1st1970.AddMilliseconds(epoch);

--- a/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/Adaptive.Aeron.Samples.BufferClaimIpcThroughput.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/Adaptive.Aeron.Samples.BufferClaimIpcThroughput.csproj
@@ -80,6 +80,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.BufferClaimIpcThroughput.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/Adaptive.Aeron.Samples.BufferClaimIpcThroughput.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/Adaptive.Aeron.Samples.BufferClaimIpcThroughput.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/BufferClaimIpcThroughput.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/BufferClaimIpcThroughput.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 using System.Threading;
 using Adaptive.Aeron.LogBuffer;

--- a/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.BufferClaimIpcThroughput/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.Common/Adaptive.Aeron.Samples.Common.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/Adaptive.Aeron.Samples.Common.csproj
@@ -83,6 +83,9 @@
       <Name>Adaptive.Agrona</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.Common.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.Common/Adaptive.Aeron.Samples.Common.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/Adaptive.Aeron.Samples.Common.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.Common/ComputerSpecifications.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/ComputerSpecifications.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 using System.Management;
 using System.Text;

--- a/src/Samples/Adaptive.Aeron.Samples.Common/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.Common/RateReporter.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/RateReporter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Threading;
 

--- a/src/Samples/Adaptive.Aeron.Samples.Common/RuntimeInformation.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/RuntimeInformation.cs
@@ -1,4 +1,20 @@
-﻿#define CLASSIC
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define CLASSIC
 
 using System;
 using System.Diagnostics;

--- a/src/Samples/Adaptive.Aeron.Samples.Common/SampleConfiguration.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/SampleConfiguration.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Adaptive.Aeron.Samples.Common
 {
     /// <summary>

--- a/src/Samples/Adaptive.Aeron.Samples.Common/SamplesUtil.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/SamplesUtil.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Text;
 using Adaptive.Aeron.LogBuffer;

--- a/src/Samples/Adaptive.Aeron.Samples.HelloWorld/Adaptive.Aeron.Samples.HelloWorld.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.HelloWorld/Adaptive.Aeron.Samples.HelloWorld.csproj
@@ -76,6 +76,9 @@
       <Name>Adaptive.Agrona</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.HelloWorld.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.HelloWorld/Adaptive.Aeron.Samples.HelloWorld.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.HelloWorld/Adaptive.Aeron.Samples.HelloWorld.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.HelloWorld/HelloWorld.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.HelloWorld/HelloWorld.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;

--- a/src/Samples/Adaptive.Aeron.Samples.HelloWorld/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.HelloWorld/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Adaptive.Aeron.Samples.IpcThroughput.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Adaptive.Aeron.Samples.IpcThroughput.csproj
@@ -81,6 +81,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.IpcThroughput.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Adaptive.Aeron.Samples.IpcThroughput.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Adaptive.Aeron.Samples.IpcThroughput.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/IpcThroughput.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/IpcThroughput.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 using System.Threading;
 using Adaptive.Aeron.LogBuffer;

--- a/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.IpcThroughput/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.Ping/Adaptive.Aeron.Samples.Ping.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.Ping/Adaptive.Aeron.Samples.Ping.csproj
@@ -86,6 +86,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.Ping.licenseheader" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Samples/Adaptive.Aeron.Samples.Ping/Adaptive.Aeron.Samples.Ping.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.Ping/Adaptive.Aeron.Samples.Ping.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.Ping/Ping.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Ping/Ping.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 using System.Threading;
 using Adaptive.Aeron.LogBuffer;

--- a/src/Samples/Adaptive.Aeron.Samples.Ping/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Ping/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.Pong/Adaptive.Aeron.Samples.Pong.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.Pong/Adaptive.Aeron.Samples.Pong.csproj
@@ -80,6 +80,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.Pong.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.Pong/Adaptive.Aeron.Samples.Pong.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.Pong/Adaptive.Aeron.Samples.Pong.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.Pong/Pong.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Pong/Pong.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Aeron.Samples.Common;
 using Adaptive.Agrona;

--- a/src/Samples/Adaptive.Aeron.Samples.Pong/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Pong/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/Adaptive.Aeron.Samples.RateSubscriber.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/Adaptive.Aeron.Samples.RateSubscriber.csproj
@@ -80,6 +80,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.RateSubscriber.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/Adaptive.Aeron.Samples.RateSubscriber.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/Adaptive.Aeron.Samples.RateSubscriber.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/RateSubscriber.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.RateSubscriber/RateSubscriber.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 using Adaptive.Aeron.Samples.Common;
 using Adaptive.Agrona.Concurrent;

--- a/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/Adaptive.Aeron.Samples.SimplePublisher.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/Adaptive.Aeron.Samples.SimplePublisher.csproj
@@ -80,6 +80,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.SimplePublisher.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/Adaptive.Aeron.Samples.SimplePublisher.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/Adaptive.Aeron.Samples.SimplePublisher.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/SimplePublisher.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/SimplePublisher.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Text;
 using System.Threading;
 using Adaptive.Agrona;

--- a/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/Adaptive.Aeron.Samples.SimpleSubscriber.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/Adaptive.Aeron.Samples.SimpleSubscriber.csproj
@@ -80,6 +80,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.SimpleSubscriber.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/Adaptive.Aeron.Samples.SimpleSubscriber.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/Adaptive.Aeron.Samples.SimpleSubscriber.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/SimpleSubscriber.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.SimpleSubscriber/SimpleSubscriber.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Text;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona.Concurrent;

--- a/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/Adaptive.Aeron.Samples.StreamingPublisher.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/Adaptive.Aeron.Samples.StreamingPublisher.csproj
@@ -81,6 +81,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.StreamingPublisher.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/Adaptive.Aeron.Samples.StreamingPublisher.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/Adaptive.Aeron.Samples.StreamingPublisher.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/IntSupplier.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/IntSupplier.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Threading;
 using Adaptive.Agrona;

--- a/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/StreamingPublisher.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.StreamingPublisher/StreamingPublisher.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 using Adaptive.Aeron.Samples.Common;
 using Adaptive.Agrona;

--- a/src/Samples/Adaptive.Aeron.Samples.Throughput/Adaptive.Aeron.Samples.Throughput.csproj
+++ b/src/Samples/Adaptive.Aeron.Samples.Throughput/Adaptive.Aeron.Samples.Throughput.csproj
@@ -80,6 +80,9 @@
       <Name>Adaptive.Aeron.Samples.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Adaptive.Aeron.Samples.Throughput.licenseheader" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Samples/Adaptive.Aeron.Samples.Throughput/Adaptive.Aeron.Samples.Throughput.licenseheader
+++ b/src/Samples/Adaptive.Aeron.Samples.Throughput/Adaptive.Aeron.Samples.Throughput.licenseheader
@@ -1,0 +1,17 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/Samples/Adaptive.Aeron.Samples.Throughput/Properties/AssemblyInfo.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Throughput/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/Adaptive.Aeron.Samples.Throughput/Throughput.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Throughput/Throughput.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2014 - 2017 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Threading;
 using Adaptive.Aeron.Samples.Common;
 using Adaptive.Agrona;


### PR DESCRIPTION
Not a big performance win if any, more like an exercise in profiling & FYI. I see 1.1% perf gain in IPC throughput, but the absolute difference is only half of stdev of samples... I mean, please check if you could see such gain as well. The reason to use ThrowHelper is that throwing methods fail to inline and/or they generate larger code size (depends on JIT).

An interesting result is related to #53 - using `Unsafe.CopyBlock` is significantly slower because this method fails to inline.

`Try/catch/finally` in `Read()` also prevents inlining, and as far as I remember there was no try/catch initially.

There is only a single implementation of `IEpochClock` as `SystemEpochClock`, in the benchmark the interface call also shows up. Not sure if its methods are hot in real loads.

Other than that, profiler results are clean as before, especially with #51 - zero GCs with cached delegates. (and dotTrace is such a breeze vs PerfView 😄)

In a recent talk published on InfoQ Martin said that this .NET implementation is the fastest among the three ones for IPC, maybe it could be even a little bit faster 😄

P.S. BTW, the media driver jar is outdated, I had to download new jars. You use a custom jar I guess, had to combine three ones in `start-media-driver.bat`.