### PR TITLE
Fix heap corruption issue in DriverProxy

### DIFF
--- a/src/Adaptive.Aeron/DriverProxy.cs
+++ b/src/Adaptive.Aeron/DriverProxy.cs
@@ -35,7 +35,9 @@ namespace Adaptive.Aeron
         /// Maximum capacity of the write buffer </summary>
         public const int MSG_BUFFER_CAPACITY = 1024;
 
-        private readonly UnsafeBuffer _buffer = new UnsafeBuffer(BufferUtil.AllocateDirectAligned(MSG_BUFFER_CAPACITY,BitUtil.CACHE_LINE_LENGTH * 2));
+        // Keep a reference to _byteBuffer prevent it from being garbage collected.  It unpins the array used by _buffer in its finalizer.
+        private readonly ByteBuffer _byteBuffer = BufferUtil.AllocateDirectAligned(MSG_BUFFER_CAPACITY, BitUtil.CACHE_LINE_LENGTH * 2);
+        private readonly UnsafeBuffer _buffer;
         private readonly PublicationMessageFlyweight _publicationMessage = new PublicationMessageFlyweight();
         private readonly SubscriptionMessageFlyweight _subscriptionMessage = new SubscriptionMessageFlyweight();
         private readonly RemoveMessageFlyweight _removeMessage = new RemoveMessageFlyweight();
@@ -46,6 +48,8 @@ namespace Adaptive.Aeron
         public DriverProxy(IRingBuffer toDriverCommandBuffer)
         {
             if (toDriverCommandBuffer == null) throw new ArgumentNullException(nameof(toDriverCommandBuffer));
+
+            _buffer = new UnsafeBuffer(_byteBuffer);
 
             _toDriverCommandBuffer = toDriverCommandBuffer;
 

--- a/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/SimplePublisher.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.SimplePublisher/SimplePublisher.cs
@@ -34,66 +34,68 @@ namespace Adaptive.Aeron.Samples.SimplePublisher
         {
             // Allocate enough buffer size to hold maximum message length
             // The UnsafeBuffer class is part of the Agrona library and is used for efficient buffer management
-            var buffer = new UnsafeBuffer(BufferUtil.AllocateDirectAligned(512, BitUtil.CACHE_LINE_LENGTH));
-
-            // The channel (an endpoint identifier) to send the message to
-            const string channel = "aeron:udp?endpoint=localhost:40123";
-
-            // A unique identifier for a stream within a channel. Stream ID 0 is reserved
-            // for internal use and should not be used by applications.
-            const int streamId = 10;
-
-            Console.WriteLine("Publishing to " + channel + " on stream Id " + streamId);
-
-            // Create a context, needed for client connection to media driver
-            // A separate media driver process needs to be running prior to starting this application
-            var ctx = new Aeron.Context();
-
-            // Create an Aeron instance with client-provided context configuration and connect to the
-            // media driver, and create a Publication.  The Aeron and Publication classes implement
-            // AutoCloseable, and will automatically clean up resources when this try block is finished.
-            using (var aeron = Aeron.Connect(ctx))
-            using (var publication = aeron.AddPublication(channel, streamId))
+            using (var byteBuffer = BufferUtil.AllocateDirectAligned(512, BitUtil.CACHE_LINE_LENGTH))
+            using (var buffer = new UnsafeBuffer(byteBuffer))
             {
-                Thread.Sleep(100);
+                // The channel (an endpoint identifier) to send the message to
+                const string channel = "aeron:udp?endpoint=localhost:40123";
 
-                const string message = "Hello World! ";
-                var messageBytes = Encoding.UTF8.GetBytes(message);
-                buffer.PutBytes(0, messageBytes);
+                // A unique identifier for a stream within a channel. Stream ID 0 is reserved
+                // for internal use and should not be used by applications.
+                const int streamId = 10;
 
-                // Try to publish the buffer. 'offer' is a non-blocking call.
-                // If it returns less than 0, the message was not sent, and the offer should be retried.
-                var result = publication.Offer(buffer, 0, messageBytes.Length);
+                Console.WriteLine("Publishing to " + channel + " on stream Id " + streamId);
 
-                if (result < 0L)
+                // Create a context, needed for client connection to media driver
+                // A separate media driver process needs to be running prior to starting this application
+                var ctx = new Aeron.Context();
+
+                // Create an Aeron instance with client-provided context configuration and connect to the
+                // media driver, and create a Publication.  The Aeron and Publication classes implement
+                // AutoCloseable, and will automatically clean up resources when this try block is finished.
+                using (var aeron = Aeron.Connect(ctx))
+                using (var publication = aeron.AddPublication(channel, streamId))
                 {
-                    switch (result)
+                    Thread.Sleep(100);
+
+                    const string message = "Hello World! ";
+                    var messageBytes = Encoding.UTF8.GetBytes(message);
+                    buffer.PutBytes(0, messageBytes);
+
+                    // Try to publish the buffer. 'offer' is a non-blocking call.
+                    // If it returns less than 0, the message was not sent, and the offer should be retried.
+                    var result = publication.Offer(buffer, 0, messageBytes.Length);
+
+                    if (result < 0L)
                     {
-                        case Publication.BACK_PRESSURED:
-                            Console.WriteLine(" Offer failed due to back pressure");
-                            break;
-                        case Publication.NOT_CONNECTED:
-                            Console.WriteLine(" Offer failed because publisher is not connected to subscriber");
-                            break;
-                        case Publication.ADMIN_ACTION:
-                            Console.WriteLine("Offer failed because of an administration action in the system");
-                            break;
-                        case Publication.CLOSED:
-                            Console.WriteLine("Offer failed publication is closed");
-                            break;
-                        default:
-                            Console.WriteLine(" Offer failed due to unknown reason");
-                            break;
+                        switch (result)
+                        {
+                            case Publication.BACK_PRESSURED:
+                                Console.WriteLine(" Offer failed due to back pressure");
+                                break;
+                            case Publication.NOT_CONNECTED:
+                                Console.WriteLine(" Offer failed because publisher is not connected to subscriber");
+                                break;
+                            case Publication.ADMIN_ACTION:
+                                Console.WriteLine("Offer failed because of an administration action in the system");
+                                break;
+                            case Publication.CLOSED:
+                                Console.WriteLine("Offer failed publication is closed");
+                                break;
+                            default:
+                                Console.WriteLine(" Offer failed due to unknown reason");
+                                break;
+                        }
                     }
-                }
-                else
-                {
-                    Console.WriteLine(" yay !!");
-                }
+                    else
+                    {
+                        Console.WriteLine(" yay !!");
+                    }
 
-                Console.WriteLine("Done sending.");
-                Console.WriteLine("Press any key...");
-                Console.ReadLine();
+                    Console.WriteLine("Done sending.");
+                    Console.WriteLine("Press any key...");
+                    Console.ReadLine();
+                }
             }
         }
     }


### PR DESCRIPTION
This commit fixes an issue where the buffer used by the DriverProxy class can become unpinned causing clients to send corrupt messages to the Media Driver.

UnsafeBuffer has a constructor that takes a ByteBuffer.  ByteBuffer contains a pointer to a managed array that has been pinned with a GCHandle.  When an UnsafeBuffer is constructed from a ByteBuffer it takes a copy of the pointer, but does not take ownership of the GCHandle.  If the ByteBuffer is allowed to be garbage collected the GCHandle is freed in its finalizer unpinning the managed array.  The unpinned array may be moved by the garbage collector leaving UnsafeBuffer pointing to invalid memory.

This commit fixes the bug by ensuring that we keep a reference to the ByteBuffer that is wrapped by the UnsafeBuffer in DriverProxy. This prevents the garbage collector from calling the ByteBuffer's finalizer and unpinning the managed array whilst it is still being used by the DriverProxy.  It also fixes a similar issue in the SimplePublisher sample.

An more invasive, but cleaner, fix would be to give UnsafeBuffer a constructor that did the job of the ByteBuffer - creating a pointer to an array with the correct alignment.  I think that in all cases that a ByteBuffer is used it's immediately passed into an UnsafeBuffer.  Please let me know if you would prefer that instead.