### PR TITLE
Tidy Up

### DIFF
--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
@@ -24,7 +24,6 @@ namespace Adaptive.Aeron.Tests.LogBuffer
     [TestFixture]
     public class TermGapFillerTest
     {
-        private bool InstanceFieldsInitialized;
         private const int INITIAL_TERM_ID = 11;
         private const int TERM_ID = 22;
         private const int SESSION_ID = 333;

--- a/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
+++ b/src/Adaptive.Aeron.Tests/LogBuffer/TermGapFillerTests.cs
@@ -35,7 +35,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         private DataHeaderFlyweight dataFlyweight;
 
         [SetUp]
-        public virtual void Setup()
+        public void Setup()
         {
             metaDataBuffer = new UnsafeBuffer(new byte[LogBufferDescriptor.LOG_META_DATA_LENGTH]);
             termBuffer = new UnsafeBuffer(new byte[LogBufferDescriptor.TERM_MIN_LENGTH]);
@@ -45,7 +45,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         }
 
         [Test]
-        public virtual void ShouldFillGapAtBeginningOfTerm()
+        public void ShouldFillGapAtBeginningOfTerm()
         {
             const int gapOffset = 0;
             const int gapLength = 64;
@@ -61,7 +61,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         }
 
         [Test]
-        public virtual void ShouldNotOverwriteExistingFrame()
+        public void ShouldNotOverwriteExistingFrame()
         {
             const int gapOffset = 0;
             const int gapLength = 64;
@@ -72,7 +72,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         }
 
         [Test]
-        public virtual void ShouldFillGapAfterExistingFrame()
+        public void ShouldFillGapAfterExistingFrame()
         {
             const int gapOffset = 128;
             const int gapLength = 64;
@@ -92,7 +92,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         }
 
         [Test]
-        public virtual void ShouldFillGapBetweenExistingFrames()
+        public void ShouldFillGapBetweenExistingFrames()
         {
             const int gapOffset = 128;
             const int gapLength = 64;
@@ -115,7 +115,7 @@ namespace Adaptive.Aeron.Tests.LogBuffer
         }
 
         [Test]
-        public virtual void ShouldFillGapAtEndOfTerm()
+        public void ShouldFillGapAtEndOfTerm()
         {
             int gapOffset = termBuffer.Capacity - 64;
             const int gapLength = 64;

--- a/src/Adaptive.Aeron/Adaptive.Aeron.csproj
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.csproj
@@ -16,6 +16,13 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="Fody" Version="3.2.16" >
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Virtuosity.Fody" Version="1.21.3" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Adaptive.Agrona\Adaptive.Agrona.csproj" />
   </ItemGroup>

--- a/src/Adaptive.Aeron/Aeron.cs
+++ b/src/Adaptive.Aeron/Aeron.cs
@@ -120,7 +120,7 @@ namespace Adaptive.Aeron
         }
 
         /// <summary>
-        /// Print out the values from <seealso cref="#countersReader()"/> which can be useful for debugging.
+        /// Print out the values from <seealso cref="CountersReader"/> which can be useful for debugging.
         /// </summary>
         ///  <param name="out"> to where the counters get printed. </param>
         public void PrintCounters(StreamWriter @out)
@@ -300,14 +300,14 @@ namespace Adaptive.Aeron
         /// <summary>
         /// Allocate a counter on the media driver and return a <seealso cref="Counter"/> for it.
         /// <para>
-        /// The counter should be freed by calling <seealso cref="Counter#close()"/>.
+        /// The counter should be freed by calling <seealso cref="Counter.Dispose()"/>.
         /// 
         /// </para>
         /// </summary>
         /// <param name="typeId"> for the counter. </param>
         /// <param name="label">  for the counter. It should be US-ASCII. </param>
         /// <returns> the newly allocated counter. </returns>
-        /// <seealso cref= org.agrona.concurrent.status.CountersManager#allocate(String, int) </seealso>
+        /// <seealso cref="CountersManager.Allocate(string,int)"></seealso>
         public Counter AddCounter(int typeId, string label)
         {
             return _conductor.AddCounter(typeId, label);
@@ -585,7 +585,7 @@ namespace Adaptive.Aeron
             /// Perform a shallow copy of the object.
             /// </summary>
             /// <returns> a shallow copy of the object. </returns>
-            public virtual Context Clone()
+            public Context Clone()
             {
                 return (Context) MemberwiseClone();
             }
@@ -769,9 +769,9 @@ namespace Adaptive.Aeron
 
 
             /// <summary>
-            /// Set the <seealso cref="NanoClock"/> to be used for tracking high resolution time.
+            /// Set the <seealso cref="INanoClock"/> to be used for tracking high resolution time.
             /// </summary>
-            /// <param name="clock"> <seealso cref="NanoClock"/> to be used for tracking high resolution time. </param>
+            /// <param name="clock"> <seealso cref="INanoClock"/> to be used for tracking high resolution time. </param>
             /// <returns> this Aeron.Context for method chaining </returns>
             public Context NanoClock(INanoClock clock)
             {
@@ -1455,6 +1455,7 @@ namespace Adaptive.Aeron
             /// Read the error log to a given <seealso cref="StreamWriter"/>
             /// </summary>
             /// <param name="writer"> to write the error log contents to. </param>
+            /// <param name="cncByteBuffer"> containing the error log.</param>
             /// <returns> the number of observations from the error log </returns>
             public int SaveErrorLog(StreamWriter writer, MappedByteBuffer cncByteBuffer)
             {
@@ -1511,7 +1512,7 @@ namespace Adaptive.Aeron
             {
                 Thread.Sleep(durationMs);
             }
-            catch (ThreadInterruptedException ignore)
+            catch (ThreadInterruptedException)
             {
                 Thread.CurrentThread.Interrupt();
             }

--- a/src/Adaptive.Aeron/ChannelUri.cs
+++ b/src/Adaptive.Aeron/ChannelUri.cs
@@ -109,7 +109,7 @@ namespace Adaptive.Aeron
         /// </summary>
         /// <param name="media"> to replace the parsed value. </param>
         /// <returns> this for a fluent API. </returns>
-        public virtual ChannelUri Media(string media)
+        public ChannelUri Media(string media)
         {
             _media = media;
             return this;

--- a/src/Adaptive.Aeron/ChannelUriStringBuilder.cs
+++ b/src/Adaptive.Aeron/ChannelUriStringBuilder.cs
@@ -526,7 +526,7 @@ namespace Adaptive.Aeron
         /// </summary>
         /// <param name="tags"> for the channel, publication or subscription. </param>
         /// <returns> this for a fluent API. </returns>
-        /// <seealso cref="Aeron.Context#TAGS_PARAM_NAME"/>
+        /// <seealso cref="Aeron.Context.TAGS_PARAM_NAME"/>
         public ChannelUriStringBuilder Tags(string tags)
         {
             _tags = tags;
@@ -537,7 +537,7 @@ namespace Adaptive.Aeron
         /// Get the tags for a channel, and/or publication or subscription.
         /// </summary>
         /// <returns> the tags for a channel, publication or subscription. </returns>
-        /// <seealso cref="Aeron.Context#TAGS_PARAM_NAME"/>
+        /// <seealso cref="Aeron.Context.TAGS_PARAM_NAME"/>
         public string Tags()
         {
             return _tags;

--- a/src/Adaptive.Aeron/ClientConductor.cs
+++ b/src/Adaptive.Aeron/ClientConductor.cs
@@ -398,7 +398,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual ExclusivePublication AddExclusivePublication(string channel, int streamId)
+        internal ExclusivePublication AddExclusivePublication(string channel, int streamId)
         {
             _clientLock.Lock();
             try
@@ -418,7 +418,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual void ReleasePublication(Publication publication)
+        internal void ReleasePublication(Publication publication)
         {
             _clientLock.Lock();
             try
@@ -450,7 +450,7 @@ namespace Adaptive.Aeron
             return AddSubscription(channel, streamId, _defaultAvailableImageHandler, _defaultUnavailableImageHandler);
         }
 
-        internal virtual Subscription AddSubscription(string channel, int streamId, AvailableImageHandler availableImageHandler, UnavailableImageHandler unavailableImageHandler)
+        internal Subscription AddSubscription(string channel, int streamId, AvailableImageHandler availableImageHandler, UnavailableImageHandler unavailableImageHandler)
         {
             _clientLock.Lock();
             try
@@ -473,7 +473,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual void ReleaseSubscription(Subscription subscription)
+        internal void ReleaseSubscription(Subscription subscription)
         {
             _clientLock.Lock();
             try
@@ -496,7 +496,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual void AddDestination(long registrationId, string endpointChannel)
+        internal void AddDestination(long registrationId, string endpointChannel)
         {
             _clientLock.Lock();
             try
@@ -512,7 +512,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual void RemoveDestination(long registrationId, string endpointChannel)
+        internal void RemoveDestination(long registrationId, string endpointChannel)
         {
             _clientLock.Lock();
             try
@@ -561,7 +561,7 @@ namespace Adaptive.Aeron
         }
 
 
-        internal virtual Counter AddCounter(int typeId, IDirectBuffer keyBuffer, int keyOffset, int keyLength, IDirectBuffer labelBuffer, int labelOffset, int labelLength)
+        internal Counter AddCounter(int typeId, IDirectBuffer keyBuffer, int keyOffset, int keyLength, IDirectBuffer labelBuffer, int labelOffset, int labelLength)
         {
             _clientLock.Lock();
             try
@@ -615,7 +615,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual void ReleaseCounter(Counter counter)
+        internal void ReleaseCounter(Counter counter)
         {
             _clientLock.Lock();
             try
@@ -640,7 +640,7 @@ namespace Adaptive.Aeron
             }
         }
 
-        internal virtual void ReleaseLogBuffers(LogBuffers logBuffers, long registrationId)
+        internal void ReleaseLogBuffers(LogBuffers logBuffers, long registrationId)
         {
             if (logBuffers.DecRef() == 0)
             {
@@ -655,7 +655,7 @@ namespace Adaptive.Aeron
             return _driverEventsAdapter;
         }
 
-        internal virtual long ChannelStatus(int channelStatusId)
+        internal long ChannelStatus(int channelStatusId)
         {
             switch (channelStatusId)
             {

--- a/src/Adaptive.Aeron/ClientConductor.cs
+++ b/src/Adaptive.Aeron/ClientConductor.cs
@@ -620,7 +620,7 @@ namespace Adaptive.Aeron
             _clientLock.Lock();
             try
             {
-                if (!counter.IsClosed())
+                if (!counter.IsClosed)
                 {
                     EnsureOpen();
                     EnsureNotReentrant();

--- a/src/Adaptive.Aeron/Command/OperationSucceededFlyweight.cs
+++ b/src/Adaptive.Aeron/Command/OperationSucceededFlyweight.cs
@@ -42,7 +42,7 @@ namespace Adaptive.Aeron.Command
         /// return correlation id field
         /// </summary>
         /// <returns> correlation id field </returns>
-        public virtual long CorrelationId()
+        public long CorrelationId()
         {
             return buffer.GetLong(offset + CORRELATION_ID_FIELD_OFFSET);
         }
@@ -52,7 +52,7 @@ namespace Adaptive.Aeron.Command
         /// </summary>
         /// <param name="correlationId"> field value </param>
         /// <returns> for fluent API </returns>
-        public virtual OperationSucceededFlyweight CorrelationId(long correlationId)
+        public OperationSucceededFlyweight CorrelationId(long correlationId)
         {
             buffer.PutLong(offset + CORRELATION_ID_FIELD_OFFSET, correlationId);
 

--- a/src/Adaptive.Aeron/ControlledFragmentAssembler.cs
+++ b/src/Adaptive.Aeron/ControlledFragmentAssembler.cs
@@ -34,9 +34,9 @@ namespace Adaptive.Aeron
     /// When sessions go inactive see <seealso cref="UnavailableImageHandler"/>, it is possible to free the buffer by calling
     /// <seealso cref="FreeSessionBuffer(int)"/>.
     /// </summary>
-    /// <seealso cref="Subscription.ControlledPoll"/>
-    /// <seealso cref="Image.ControlledPoll"/>
-    /// <seealso cref="Image.ControlledPeek"/>
+    /// <seealso cref="Subscription.ControlledPoll(Adaptive.Aeron.LogBuffer.IControlledFragmentHandler,int)"/>
+    /// <seealso cref="Image.ControlledPoll(Adaptive.Aeron.LogBuffer.IControlledFragmentHandler,int)"/>
+    /// <seealso cref="Image.ControlledPeek(long,Adaptive.Aeron.LogBuffer.IControlledFragmentHandler,long)"/>
     public class ControlledFragmentAssembler : IControlledFragmentHandler
     {
         private readonly int _initialBufferLength;

--- a/src/Adaptive.Aeron/Counter.cs
+++ b/src/Adaptive.Aeron/Counter.cs
@@ -24,7 +24,7 @@ namespace Adaptive.Aeron
         /// Construct a read-write view of an existing counter.
         /// </summary>
         /// <param name="countersReader"> for getting access to the buffers. </param>
-        /// <param name="registrationId"> assigned by the driver for the counter or <see cref="Aeron.NULL_VALUE"/> if not known. </param>
+        /// <param name="registrationId"> assigned by the driver for the counter or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if not known. </param>
         /// <param name="counterId">      for the counter to be viewed. </param>
         /// <exception cref="AeronException"> if the id has for the counter has not been allocated. </exception>
         internal Counter(CountersReader countersReader, long registrationId, int counterId) : base(
@@ -73,10 +73,7 @@ namespace Adaptive.Aeron
         /// Has this object been closed and should no longer be used?
         /// </summary>
         /// <returns> true if it has been closed otherwise false. </returns>
-        public bool IsClosed()
-        {
-            return isClosed;
-        }
+        public override bool IsClosed => isClosed;
 
         internal void InternalClose()
         {

--- a/src/Adaptive.Aeron/Counter.cs
+++ b/src/Adaptive.Aeron/Counter.cs
@@ -43,7 +43,7 @@ namespace Adaptive.Aeron
         /// Return the registration id used to register this counter with the media driver.
         /// </summary>
         /// <returns> registration id </returns>
-        public virtual long RegistrationId()
+        public long RegistrationId()
         {
             return registrationId;
         }
@@ -73,12 +73,12 @@ namespace Adaptive.Aeron
         /// Has this object been closed and should no longer be used?
         /// </summary>
         /// <returns> true if it has been closed otherwise false. </returns>
-        public virtual bool IsClosed()
+        public bool IsClosed()
         {
             return isClosed;
         }
 
-        internal virtual void InternalClose()
+        internal void InternalClose()
         {
             base.Dispose();
             isClosed = true;

--- a/src/Adaptive.Aeron/DriverProxy.cs
+++ b/src/Adaptive.Aeron/DriverProxy.cs
@@ -68,11 +68,7 @@ namespace Adaptive.Aeron
             return _toDriverCommandBuffer.ConsumerHeartbeatTime();
         }
 
-#if DEBUG
-        public virtual long AddPublication(string channel, int streamId)
-#else
         public long AddPublication(string channel, int streamId)
-#endif
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
@@ -82,7 +78,8 @@ namespace Adaptive.Aeron
                 .StreamId(streamId)
                 .Channel(channel);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_PUBLICATION, _buffer, 0, _publicationMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_PUBLICATION, _buffer, 0,
+                _publicationMessage.Length()))
             {
                 throw new AeronException("Could not write add publication command");
             }
@@ -90,12 +87,7 @@ namespace Adaptive.Aeron
             return correlationId;
         }
 
-
-#if DEBUG
-        public virtual long AddExclusivePublication(string channel, int streamId)
-#else
         public long AddExclusivePublication(string channel, int streamId)
-#endif
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
@@ -105,7 +97,8 @@ namespace Adaptive.Aeron
                 .StreamId(streamId)
                 .Channel(channel);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_EXCLUSIVE_PUBLICATION, _buffer, 0, _publicationMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_EXCLUSIVE_PUBLICATION, _buffer, 0,
+                _publicationMessage.Length()))
             {
                 throw new AeronException("Could not write add exclusive publication command");
             }
@@ -113,17 +106,14 @@ namespace Adaptive.Aeron
             return correlationId;
         }
 
-#if DEBUG
-        public virtual long RemovePublication(long registrationId)
-#else
         public long RemovePublication(long registrationId)
-#endif
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
             _removeMessage.RegistrationId(registrationId).CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_PUBLICATION, _buffer, 0, RemoveMessageFlyweight.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_PUBLICATION, _buffer, 0,
+                RemoveMessageFlyweight.Length()))
             {
                 throw new AeronException("Could not write remove publication command");
             }
@@ -131,11 +121,7 @@ namespace Adaptive.Aeron
             return correlationId;
         }
 
-#if DEBUG
-        public virtual long AddSubscription(string channel, int streamId)
-#else
         public long AddSubscription(string channel, int streamId)
-#endif
         {
             const long registrationId = Aeron.NULL_VALUE;
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
@@ -144,7 +130,8 @@ namespace Adaptive.Aeron
 
             _subscriptionMessage.RegistrationCorrelationId(registrationId).StreamId(streamId).Channel(channel);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_SUBSCRIPTION, _buffer, 0, _subscriptionMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_SUBSCRIPTION, _buffer, 0,
+                _subscriptionMessage.Length()))
             {
                 throw new AeronException("Could not write add subscription command");
             }
@@ -152,17 +139,14 @@ namespace Adaptive.Aeron
             return correlationId;
         }
 
-#if DEBUG
-        public virtual long RemoveSubscription(long registrationId)
-#else
         public long RemoveSubscription(long registrationId)
-#endif
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
             _removeMessage.RegistrationId(registrationId).CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_SUBSCRIPTION, _buffer, 0, RemoveMessageFlyweight.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_SUBSCRIPTION, _buffer, 0,
+                RemoveMessageFlyweight.Length()))
             {
                 throw new AeronException("Could not write remove subscription message");
             }
@@ -174,7 +158,8 @@ namespace Adaptive.Aeron
         {
             _correlatedMessage.CorrelationId(0);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.CLIENT_KEEPALIVE, _buffer, 0, CorrelatedMessageFlyweight.LENGTH))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.CLIENT_KEEPALIVE, _buffer, 0,
+                CorrelatedMessageFlyweight.LENGTH))
             {
                 throw new AeronException("Could not send client keepalive command");
             }
@@ -184,9 +169,11 @@ namespace Adaptive.Aeron
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
-            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel).CorrelationId(correlationId);
+            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel)
+                .CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_DESTINATION, _buffer, 0, _destinationMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_DESTINATION, _buffer, 0,
+                _destinationMessage.Length()))
             {
                 throw new AeronException("Could not write destination command");
             }
@@ -198,23 +185,27 @@ namespace Adaptive.Aeron
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
-            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel).CorrelationId(correlationId);
+            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel)
+                .CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_DESTINATION, _buffer, 0, _destinationMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_DESTINATION, _buffer, 0,
+                _destinationMessage.Length()))
             {
                 throw new AeronException("Could not write destination command");
             }
 
             return correlationId;
         }
-        
+
         public long AddRcvDestination(long registrationId, string endpointChannel)
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
-            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel).CorrelationId(correlationId);
+            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel)
+                .CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_RCV_DESTINATION, _buffer, 0, _destinationMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_RCV_DESTINATION, _buffer, 0,
+                _destinationMessage.Length()))
             {
                 throw new AeronException("Could not write rcv destination command");
             }
@@ -226,9 +217,11 @@ namespace Adaptive.Aeron
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
-            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel).CorrelationId(correlationId);
+            _destinationMessage.RegistrationCorrelationId(registrationId).Channel(endpointChannel)
+                .CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_RCV_DESTINATION, _buffer, 0, _destinationMessage.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_RCV_DESTINATION, _buffer, 0,
+                _destinationMessage.Length()))
             {
                 throw new AeronException("Could not write rcv destination command");
             }
@@ -236,12 +229,14 @@ namespace Adaptive.Aeron
             return correlationId;
         }
 
-        
-        public long AddCounter(int typeId, IDirectBuffer keyBuffer, int keyOffset, int keyLength, IDirectBuffer labelBuffer, int labelOffset, int labelLength)
+
+        public long AddCounter(int typeId, IDirectBuffer keyBuffer, int keyOffset, int keyLength,
+            IDirectBuffer labelBuffer, int labelOffset, int labelLength)
         {
             long correlationId = _toDriverCommandBuffer.NextCorrelationId();
 
-            _counterMessage.TypeId(typeId).KeyBuffer(keyBuffer, keyOffset, keyLength).LabelBuffer(labelBuffer, labelOffset, labelLength).CorrelationId(correlationId);
+            _counterMessage.TypeId(typeId).KeyBuffer(keyBuffer, keyOffset, keyLength)
+                .LabelBuffer(labelBuffer, labelOffset, labelLength).CorrelationId(correlationId);
 
             if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.ADD_COUNTER, _buffer, 0, _counterMessage.Length()))
             {
@@ -271,7 +266,8 @@ namespace Adaptive.Aeron
 
             _removeMessage.RegistrationId(registrationId).CorrelationId(correlationId);
 
-            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_COUNTER, _buffer, 0, RemoveMessageFlyweight.Length()))
+            if (!_toDriverCommandBuffer.Write(ControlProtocolEvents.REMOVE_COUNTER, _buffer, 0,
+                RemoveMessageFlyweight.Length()))
             {
                 throw new AeronException("Could not write remove counter command");
             }
@@ -279,7 +275,7 @@ namespace Adaptive.Aeron
             return correlationId;
         }
 
-        public virtual void ClientClose()
+        public void ClientClose()
         {
             _correlatedMessage.CorrelationId(_toDriverCommandBuffer.NextCorrelationId());
             _toDriverCommandBuffer.Write(ControlProtocolEvents.CLIENT_CLOSE, _buffer, 0, CorrelatedMessageFlyweight.LENGTH);

--- a/src/Adaptive.Aeron/Exceptions/RegistrationException.cs
+++ b/src/Adaptive.Aeron/Exceptions/RegistrationException.cs
@@ -42,7 +42,7 @@ namespace Adaptive.Aeron.Exceptions
 
         /// <summary>
         /// Value of the errorCode encoded. This can provide additional information when a
-        /// <seealso cref="ErrorCode#UNKNOWN_CODE_VALUE"/> is returned.
+        /// <seealso cref="Adaptive.Aeron.ErrorCode.UNKNOWN_CODE_VALUE"/> is returned.
         /// </summary>
         /// <returns> value of the errorCode encoded as an int. </returns>
         public int ErrorCodeValue()

--- a/src/Adaptive.Aeron/ExclusivePublication.cs
+++ b/src/Adaptive.Aeron/ExclusivePublication.cs
@@ -191,7 +191,7 @@ namespace Adaptive.Aeron
 
         /// <summary>
         /// Try to claim a range in the publication log into which a message can be written with zero copy semantics.
-        /// Once the message has been written then <seealso cref="ExclusiveBufferClaim.Commit()"/> should be called thus making it available.
+        /// Once the message has been written then <seealso cref="BufferClaim.Commit()"/> should be called thus making it available.
         /// 
         /// <b>Note:</b> This method can only be used for message lengths less than MTU length minus header.
         /// If the claim is held after the publication is closed, or the client dies, then it will be unblocked to reach

--- a/src/Adaptive.Aeron/ExclusivePublication.cs
+++ b/src/Adaptive.Aeron/ExclusivePublication.cs
@@ -257,7 +257,7 @@ namespace Adaptive.Aeron
         /// <returns> The new stream position, otherwise a negative error value of <seealso cref="Publication.NOT_CONNECTED"/>,
         /// <seealso cref="Publication.BACK_PRESSURED"/>, <seealso cref="Publication.ADMIN_ACTION"/>, <seealso cref="Publication.CLOSED"/>, or <seealso cref="Publication.MAX_POSITION_EXCEEDED"/>. </returns>
         /// <exception cref="ArgumentException"> if the length is greater than <seealso cref="Publication.MaxMessageLength()"/>. </exception>
-        public virtual long AppendPadding(int length)
+        public long AppendPadding(int length)
         {
             CheckForMaxMessageLength(length);
             long newPosition = CLOSED;

--- a/src/Adaptive.Aeron/FodyWeavers.xml
+++ b/src/Adaptive.Aeron/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+  <Virtuosity/>
+</Weavers>

--- a/src/Adaptive.Aeron/FragmentAssembler.cs
+++ b/src/Adaptive.Aeron/FragmentAssembler.cs
@@ -34,8 +34,8 @@ namespace Adaptive.Aeron
     /// When sessions go inactive see <seealso cref="UnavailableImageHandler"/>, it is possible to free the buffer by calling
     /// <seealso cref="FreeSessionBuffer(int)"/>.
     /// 
-    /// <see cref="Subscription.Poll"/>
-    /// <see cref="Image.Poll"/>
+    /// <see cref="Subscription.Poll(Adaptive.Aeron.LogBuffer.FragmentHandler,int)"/>
+    /// <see cref="Image.Poll(Adaptive.Aeron.LogBuffer.FragmentHandler,int) "/>
     /// </summary>
     public class FragmentAssembler : IFragmentHandler
     {

--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -33,7 +33,7 @@ namespace Adaptive.Aeron
     /// receive whole messages, whether or not they were fragmented, then the Subscriber
     /// should be created with a <seealso cref="FragmentAssembler"/> or a custom implementation.
     /// 
-    /// It is an application's responsibility to <seealso cref="Poll"/> the <seealso cref="Image"/> for new messages.
+    /// It is an application's responsibility to <seealso cref="Poll(Adaptive.Aeron.LogBuffer.FragmentHandler,int)"/> the <seealso cref="Image"/> for new messages.
     /// 
     /// <b>Note:</b>Images are not threadsafe and should not be shared between subscribers.
     /// </summary>

--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -123,7 +123,7 @@ namespace Adaptive.Aeron
         /// The correlationId for identification of the image with the media driver.
         /// </summary>
         /// <returns> the correlationId for identification of the image with the media driver. </returns>
-        public virtual long CorrelationId { get; }
+        public long CorrelationId { get; }
 
         /// <summary>
         /// Get the <seealso cref="Subscription"/> to which this <seealso cref="Image"/> belongs.
@@ -217,11 +217,7 @@ namespace Adaptive.Aeron
         /// <returns> the number of fragments that have been consumed. </returns>
         /// <seealso cref="FragmentAssembler" />
         /// <seealso cref="ImageFragmentAssembler" />
-#if DEBUG
-        public virtual int Poll(FragmentHandler fragmentHandler, int fragmentLimit)
-#else
         public int Poll(FragmentHandler fragmentHandler, int fragmentLimit)
-#endif
         {
             var handler = HandlerHelper.ToFragmentHandler(fragmentHandler);
             return Poll(handler, fragmentLimit);
@@ -238,11 +234,7 @@ namespace Adaptive.Aeron
         /// <returns> the number of fragments that have been consumed. </returns>
         /// <seealso cref="FragmentAssembler" />
         /// <seealso cref="ImageFragmentAssembler" />
-#if DEBUG
-        public virtual int Poll(IFragmentHandler fragmentHandler, int fragmentLimit)
-#else
         public int Poll(IFragmentHandler fragmentHandler, int fragmentLimit)
-#endif
         {
             if (_isClosed)
             {
@@ -385,7 +377,7 @@ namespace Adaptive.Aeron
         /// <returns> the number of fragments that have been consumed. </returns>
         /// <seealso cref="ControlledFragmentAssembler"/>
         /// <seealso cref="ImageControlledFragmentAssembler"/>
-        public virtual int BoundedControlledPoll(IControlledFragmentHandler handler, long maxPosition,
+        public int BoundedControlledPoll(IControlledFragmentHandler handler, long maxPosition,
             int fragmentLimit)
         {
             if (_isClosed)
@@ -477,7 +469,7 @@ namespace Adaptive.Aeron
         /// <returns> the number of fragments that have been consumed. </returns>
         /// <seealso cref="ControlledFragmentAssembler"/>
         /// <seealso cref="ImageControlledFragmentAssembler"/>
-        public virtual int BoundedControlledPoll(ControlledFragmentHandler handler, long maxPosition,
+        public int BoundedControlledPoll(ControlledFragmentHandler handler, long maxPosition,
             int fragmentLimit)
         {
             var fragmentHandler = HandlerHelper.ToControlledFragmentHandler(handler);
@@ -498,7 +490,7 @@ namespace Adaptive.Aeron
         /// <returns> the resulting position after the scan terminates which is a complete message. </returns>
         /// <seealso cref="ControlledFragmentAssembler"/>
         /// <seealso cref="ImageControlledFragmentAssembler"/>
-        public virtual long ControlledPeek(long initialPosition, IControlledFragmentHandler handler, long limitPosition)
+        public long ControlledPeek(long initialPosition, IControlledFragmentHandler handler, long limitPosition)
         {
             if (_isClosed)
             {
@@ -574,7 +566,7 @@ namespace Adaptive.Aeron
             return resultingPosition;
         }
 
-        public virtual long ControlledPeek(long initialPosition, ControlledFragmentHandler handler, long limitPosition)
+        public long ControlledPeek(long initialPosition, ControlledFragmentHandler handler, long limitPosition)
         {
             var fragmentHandler = HandlerHelper.ToControlledFragmentHandler(handler);
             return ControlledPeek(initialPosition, fragmentHandler, limitPosition);

--- a/src/Adaptive.Aeron/ImageControlledFragmentHandler.cs
+++ b/src/Adaptive.Aeron/ImageControlledFragmentHandler.cs
@@ -35,7 +35,7 @@ namespace Adaptive.Aeron
         /// Get the delegate unto which assembled messages are delegated.
         /// </summary>
         /// <returns>  the delegate unto which assembled messages are delegated. </returns>
-        public virtual IControlledFragmentHandler Delegate()
+        public IControlledFragmentHandler Delegate()
         {
             return _delegate;
         }

--- a/src/Adaptive.Aeron/ImageControlledFragmentHandler.cs
+++ b/src/Adaptive.Aeron/ImageControlledFragmentHandler.cs
@@ -25,7 +25,7 @@ namespace Adaptive.Aeron
         /// </summary>
         /// <param name="delegate">            onto which whole messages are forwarded. </param>
         /// <param name="initialBufferLength"> to be used for each session. </param>
-        public ImageControlledFragmentAssembler(IControlledFragmentHandler @delegate, int initialBufferLength = 0, bool isDirect = false)
+        public ImageControlledFragmentAssembler(IControlledFragmentHandler @delegate, int initialBufferLength = 0)
         {
             _delegate = @delegate;
             _builder = new BufferBuilder(initialBufferLength);

--- a/src/Adaptive.Aeron/ImageFragmentAssembler.cs
+++ b/src/Adaptive.Aeron/ImageFragmentAssembler.cs
@@ -16,25 +16,19 @@
 
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;
-using Adaptive.Agrona.Concurrent;
 
 namespace Adaptive.Aeron
 {
     /// <summary>
     /// A <seealso cref="IFragmentHandler"/> that sits in a chain-of-responsibility pattern that reassembles fragmented messages
-    /// so that the next handler in the chain only sees whole messages.
+    /// so that the next handler in the chain only sees whole messages. This is for a single session on an {@link Image}
+    /// and not for multiple session <see cref="Image"/>s in a <see cref="Subscription"/>.
     /// 
     /// Unfragmented messages are delegated without copy. Fragmented messages are copied to a temporary
     /// buffer for reassembly before delegation.
     /// 
     /// The <seealso cref="Header"/> passed to the _delegate on assembling a message will be that of the last fragment.
     /// 
-    /// Session based buffers will be allocated and grown as necessary based on the length of messages to be assembled.
-    /// When sessions go inactive see <seealso cref="UnavailableImageHandler"/>, it is possible to free the buffer by calling
-    /// <seealso cref="FreeSessionBuffer(int)"/>.
-    /// 
-    /// <see cref="Subscription.Poll"/>
-    /// <see cref="Image.Poll"/>
     /// </summary>
     public class ImageFragmentAssembler : IFragmentHandler
     {

--- a/src/Adaptive.Aeron/LogBuffer/ExclusiveBufferClaim.cs
+++ b/src/Adaptive.Aeron/LogBuffer/ExclusiveBufferClaim.cs
@@ -10,10 +10,11 @@ namespace Adaptive.Aeron.LogBuffer
     /// can be manipulated for setting flags and type. This allows the user to implement things such as their own
     /// fragmentation policy.
     /// 
-    /// The claimed space is in <seealso cref="Buffer()"/> between <seealso cref="Offset()"/> and <seealso cref="Offset()"/> + <seealso cref="Length()"/>.
-    /// When the buffer is filled with message data, use <seealso cref="Commit()"/> to make it available to subscribers.
+    /// The claimed space is in <seealso cref="BufferClaim.Buffer"/> between <seealso cref="BufferClaim.Offset"/>
+    /// and <seealso cref="BufferClaim.Offset"/> + <seealso cref="BufferClaim.Length"/>.
+    /// When the buffer is filled with message data, use <seealso cref="BufferClaim.Commit()"/> to make it available to subscribers.
     /// 
-    /// If the claimed space is no longer required it can be aborted by calling <seealso cref="Abort()"/>.
+    /// If the claimed space is no longer required it can be aborted by calling <seealso cref="BufferClaim.Abort()"/>.
     /// 
     /// <a href="https://github.com/real-logic/Aeron/wiki/Protocol-Specification#data-frame">Data Frame</a>
     /// </summary>
@@ -22,12 +23,12 @@ namespace Adaptive.Aeron.LogBuffer
         /// <summary>
         /// Write the provided value into the reserved space at the end of the data frame header.
         /// 
-        /// Note: The value will be written in <seealso cref="ByteOrder#LITTLE_ENDIAN"/> format.
+        /// Note: The value will be written in <seealso cref="ByteOrder.LittleEndian"/> format.
         /// </summary>
         /// <param name="value"> to be stored in the reserve space at the end of a data frame header. </param>
         /// <returns> this for fluent API semantics. </returns>
         /// <seealso cref="DataHeaderFlyweight"/>
-        public ExclusiveBufferClaim ReservedValue(long value)
+        public new ExclusiveBufferClaim ReservedValue(long value)
         {
             _buffer.PutLong(DataHeaderFlyweight.RESERVED_VALUE_OFFSET, value, ByteOrder.LittleEndian);
             return this;

--- a/src/Adaptive.Aeron/LogBuffer/ExclusiveTermAppender.cs
+++ b/src/Adaptive.Aeron/LogBuffer/ExclusiveTermAppender.cs
@@ -147,16 +147,6 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="reservedValueSupplier"><see cref="ReservedValueSupplier"/> for the frame</param>
         /// <returns> the resulting offset of the term after the append on success otherwise <seealso cref="FAILED"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int AppendUnfragmentedMessage(
-            int termId,
-            int termOffset,
-            HeaderWriter header, 
-            IDirectBuffer srcBuffer, 
-            int srcOffset, 
-            int length, 
-            ReservedValueSupplier reservedValueSupplier)
-#else
         public int AppendUnfragmentedMessage(
             int termId,
             int termOffset, 
@@ -165,7 +155,6 @@ namespace Adaptive.Aeron.LogBuffer
             int srcOffset, 
             int length, 
             ReservedValueSupplier reservedValueSupplier)
-#endif
         {
             int frameLength = length + DataHeaderFlyweight.HEADER_LENGTH;
             int alignedLength = BitUtil.Align(frameLength, FrameDescriptor.FRAME_ALIGNMENT);
@@ -208,15 +197,6 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="reservedValueSupplier"><see cref="ReservedValueSupplier"/> for the frame</param>
         /// <returns> the resulting offset of the term after the append on success otherwise <seealso cref="FAILED"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int AppendUnfragmentedMessage(
-            int termId,
-            int termOffset,
-            HeaderWriter header, 
-            DirectBufferVector[] vectors,
-            int length, 
-            ReservedValueSupplier reservedValueSupplier)
-#else
         public int AppendUnfragmentedMessage(
             int termId,
             int termOffset, 
@@ -224,7 +204,6 @@ namespace Adaptive.Aeron.LogBuffer
             DirectBufferVector[] vectors, 
             int length, 
             ReservedValueSupplier reservedValueSupplier)
-#endif
         {
             int frameLength = length + DataHeaderFlyweight.HEADER_LENGTH;
             int alignedLength = BitUtil.Align(frameLength, FrameDescriptor.FRAME_ALIGNMENT);

--- a/src/Adaptive.Aeron/LogBuffer/Header.cs
+++ b/src/Adaptive.Aeron/LogBuffer/Header.cs
@@ -147,9 +147,9 @@ namespace Adaptive.Aeron.LogBuffer
         public int TermOffset => Offset;
 
         /// <summary>
-        /// The type of the the frame which should always be <seealso cref="DataHeaderFlyweight.HDR_TYPE_DATA"/>
+        /// The type of the the frame which should always be <seealso cref="HeaderFlyweight.HDR_TYPE_DATA"/>
         /// </summary>
-        /// <returns> type of the the frame which should always be <seealso cref="DataHeaderFlyweight.HDR_TYPE_DATA"/> </returns>
+        /// <returns> type of the the frame which should always be <seealso cref="HeaderFlyweight.HDR_TYPE_DATA"/> </returns>
         public int Type => Buffer.GetShort(Offset + HeaderFlyweight.TYPE_FIELD_OFFSET) & 0xFFFF;
 
         /// <summary>

--- a/src/Adaptive.Aeron/LogBuffer/Header.cs
+++ b/src/Adaptive.Aeron/LogBuffer/Header.cs
@@ -158,11 +158,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// can be used for both flags.
         /// </summary>
         /// <returns> the flags for this frame. </returns>
-#if DEBUG
-        public virtual byte Flags => Buffer.GetByte(Offset + HeaderFlyweight.FLAGS_FIELD_OFFSET);
-#else
         public byte Flags => Buffer.GetByte(Offset + HeaderFlyweight.FLAGS_FIELD_OFFSET);
-#endif
 
         /// <summary>
         /// Get the value stored in the reserve space at the end of a data frame header.

--- a/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
+++ b/src/Adaptive.Aeron/LogBuffer/HeaderWriter.cs
@@ -52,11 +52,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="length">     of the fragment including the header. </param>
         /// <param name="termId">     of the current term buffer. </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void Write(UnsafeBuffer termBuffer, int offset, int length, int termId)
-#else
         public void Write(UnsafeBuffer termBuffer, int offset, int length, int termId)
-#endif
         {
             var lengthVersionFlagsType = _versionFlagsType | (-length & 0xFFFFFFFFL);
             var termOffsetSessionId = _sessionId | (uint)offset;

--- a/src/Adaptive.Aeron/LogBuffer/TermAppender.cs
+++ b/src/Adaptive.Aeron/LogBuffer/TermAppender.cs
@@ -123,11 +123,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="activeTermId"> used for flow control. </param>
         /// <returns> the resulting offset of the term after the append on success otherwise <seealso cref="FAILED"/>. </returns> 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int AppendUnfragmentedMessage(HeaderWriter header, IDirectBuffer srcBuffer, int srcOffset, int length, ReservedValueSupplier reservedValueSupplier, int activeTermId)
-#else
         public int AppendUnfragmentedMessage(HeaderWriter header, IDirectBuffer srcBuffer, int srcOffset, int length, ReservedValueSupplier reservedValueSupplier, int activeTermId)
-#endif
         {
             int frameLength = length + DataHeaderFlyweight.HEADER_LENGTH;
             int alignedLength = BitUtil.Align(frameLength, FrameDescriptor.FRAME_ALIGNMENT);
@@ -172,11 +168,7 @@ namespace Adaptive.Aeron.LogBuffer
         /// <param name="activeTermId"> used for flow control. </param>
         /// <returns> the resulting offset of the term after the append on success otherwise <seealso cref="FAILED"/>. </returns> 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int AppendUnfragmentedMessage(HeaderWriter header, DirectBufferVector[] vectors, int length, ReservedValueSupplier reservedValueSupplier, int activeTermId)
-#else
         public int AppendUnfragmentedMessage(HeaderWriter header, DirectBufferVector[] vectors, int length, ReservedValueSupplier reservedValueSupplier, int activeTermId)
-#endif
         {
             int frameLength = length + DataHeaderFlyweight.HEADER_LENGTH;
             int alignedLength = BitUtil.Align(frameLength, FrameDescriptor.FRAME_ALIGNMENT);

--- a/src/Adaptive.Aeron/LogBuffers.cs
+++ b/src/Adaptive.Aeron/LogBuffers.cs
@@ -125,33 +125,21 @@ namespace Adaptive.Aeron
             }
         }
 
-#if DEBUG
-        public virtual UnsafeBuffer[] DuplicateTermBuffers()
-#else
         public UnsafeBuffer[] DuplicateTermBuffers()
-#endif
         {
             return _termBuffers;
         }
 
-#if DEBUG
-        public virtual UnsafeBuffer MetaDataBuffer()
-#else
         /// <summary>
         /// Get the buffer which holds the log metadata.
         /// </summary>
         /// <returns> the buffer which holds the log metadata. </returns>
         public UnsafeBuffer MetaDataBuffer()
-#endif
         {
             return _logMetaDataBuffer;
         }
 
-#if DEBUG
-        public virtual void Dispose()
-#else
         public void Dispose()
-#endif
         {
             foreach (var buffer in _mappedByteBuffers)
             {
@@ -159,15 +147,11 @@ namespace Adaptive.Aeron
             }
         }
 
-#if DEBUG
-        public virtual int TermLength()
-#else
         /// <summary>
         ///  The length of the term buffer in each log partition.
         /// </summary>
         /// <returns> length of the term buffer in each log partition. </returns>
         public int TermLength()
-#endif
         {
             return _termLength;
         }

--- a/src/Adaptive.Aeron/Publication.cs
+++ b/src/Adaptive.Aeron/Publication.cs
@@ -29,8 +29,8 @@ namespace Adaptive.Aeron
 {
     /// <summary>
     /// Aeron publisher API for sending messages to subscribers of a given channel and streamId pair. <seealso cref="Publication"/>s
-    /// are created via the <seealso cref="Aeron#addPublication(String, int)"/> <seealso cref="Aeron#addExclusivePublication(String, int)"/>
-    /// methods, and messages are sent via one of the <seealso cref="#offer(DirectBuffer)"/> methods.
+    /// are created via the <seealso cref="Aeron.AddPublication(string, int)"/> <seealso cref="Aeron.AddExclusivePublication(string, int)"/>
+    /// methods, and messages are sent via one of the <seealso cref="Offer(UnsafeBuffer)"/> methods.
     /// <para>
     /// The APIs used for tryClaim and offer are non-blocking.
     /// </para>
@@ -225,8 +225,8 @@ namespace Adaptive.Aeron
         /// <summary>
         /// Get the status of the media channel for this Publication.
         /// <para>
-        /// The status will be <seealso cref="ChannelEndpointStatus#ERRORED"/> if a socket exception occurs on setup
-        /// and <seealso cref="ChannelEndpointStatus#ACTIVE"/> if all is well.
+        /// The status will be <seealso cref="ChannelEndpointStatus.ERRORED"/> if a socket exception occurs on setup
+        /// and <seealso cref="ChannelEndpointStatus.ACTIVE"/> if all is well.
         ///     
         /// </para>
         /// </summary>
@@ -361,8 +361,7 @@ namespace Adaptive.Aeron
         ///         }
         ///     }
         /// }</pre>
-        ///     
-        /// </para>
+        /// 
         /// </summary>
         /// <param name="length">      of the range to claim, in bytes.. </param>
         /// <param name="bufferClaim"> to be populated if the claim succeeds. </param>

--- a/src/Adaptive.Aeron/Status/ReadableCounter.cs
+++ b/src/Adaptive.Aeron/Status/ReadableCounter.cs
@@ -27,7 +27,7 @@ namespace Adaptive.Aeron.Status
         /// Construct a view of an existing counter.
         /// </summary>
         /// <param name="countersReader"> for getting access to the buffers. </param>
-        /// <param name="registrationId"> assigned by the driver for the counter or <see cref="Aeron.NULL_VALUE"/> if not known. </param>
+        /// <param name="registrationId"> assigned by the driver for the counter or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if not known. </param>
         /// <param name="counterId">      for the counter to be viewed. </param>
         /// <exception cref="InvalidOperationException"> if the id has for the counter has not been allocated. </exception>
         public ReadableCounter(CountersReader countersReader, long registrationId, int counterId)
@@ -101,7 +101,7 @@ namespace Adaptive.Aeron.Status
         /// <summary>
         /// Get the latest value for the counter with volatile semantics.
         /// <para>
-        /// <b>Note:</b>The user should call <seealso cref="#isClosed()"/> and ensure the result is false to avoid a race on reading
+        /// <b>Note:</b>The user should call <seealso cref="IsClosed()"/> and ensure the result is false to avoid a race on reading
         /// a closed counter.
         /// 
         /// </para>

--- a/src/Adaptive.Aeron/Status/ReadableCounter.cs
+++ b/src/Adaptive.Aeron/Status/ReadableCounter.cs
@@ -63,7 +63,7 @@ namespace Adaptive.Aeron.Status
         /// Return the registration Id for the counter.
         /// </summary>
         /// <returns> registration Id. </returns>
-        public virtual long RegistrationId()
+        public long RegistrationId()
         {
             return registrationId;
         }
@@ -72,7 +72,7 @@ namespace Adaptive.Aeron.Status
         /// Return the counter Id.
         /// </summary>
         /// <returns> counter Id. </returns>
-        public virtual int CounterId()
+        public int CounterId()
         {
             return counterId;
         }
@@ -84,7 +84,7 @@ namespace Adaptive.Aeron.Status
         /// <seealso cref="CountersReader.RECORD_RECLAIMED"/>
         /// <seealso cref="CountersReader.RECORD_UNUSED"/>
         /// <returns> state for the counter. </returns>
-        public virtual int State()
+        public int State()
         {
             return countersReader.GetCounterState(counterId);
         }
@@ -93,7 +93,7 @@ namespace Adaptive.Aeron.Status
         /// Return the counter label.
         /// </summary>
         /// <returns> the counter label. </returns>
-        public virtual string Label()
+        public string Label()
         {
             return countersReader.GetCounterLabel(counterId);
         }
@@ -107,7 +107,7 @@ namespace Adaptive.Aeron.Status
         /// </para>
         /// </summary>
         /// <returns> the latest value for the counter. </returns>
-        public virtual long Get()
+        public long Get()
         {
             // return UnsafeAccess.UNSAFE.getLongVolatile(buffer, addressOffset);
             
@@ -118,7 +118,7 @@ namespace Adaptive.Aeron.Status
         /// Get the value of the counter using weak ordering semantics. This is the same a standard read of a field.
         /// </summary>
         /// <returns> the  value for the counter. </returns>
-        public virtual long GetWeak()
+        public long GetWeak()
         {
             // UnsafeAccess.UNSAFE.getLong(buffer, addressOffset);
             
@@ -128,7 +128,7 @@ namespace Adaptive.Aeron.Status
         /// <summary>
         /// Close this counter. This has no impact on the <seealso cref="Counter"/> it is viewing.
         /// </summary>
-        public virtual void Dispose()
+        public void Dispose()
         {
             isClosed = true;
         }
@@ -137,7 +137,7 @@ namespace Adaptive.Aeron.Status
         /// Has this counters been closed and should no longer be used?
         /// </summary>
         /// <returns> true if it has been closed otherwise false. </returns>
-        public virtual bool IsClosed()
+        public bool IsClosed()
         {
             return isClosed;
         }

--- a/src/Adaptive.Aeron/Subscription.cs
+++ b/src/Adaptive.Aeron/Subscription.cs
@@ -407,11 +407,7 @@ namespace Adaptive.Aeron
         /// This method is idempotent.
         /// </para>
         /// </summary>
-#if DEBUG
-        public virtual void Dispose()
-#else
         public void Dispose()
-#endif
         {
             if (!_fields.isClosed)
             {

--- a/src/Adaptive.Aeron/Subscription.cs
+++ b/src/Adaptive.Aeron/Subscription.cs
@@ -61,7 +61,7 @@ namespace Adaptive.Aeron
 
             this.registrationId = registrationId;
             this.streamId = streamId;
-            this.conductor = clientConductor;
+            conductor = clientConductor;
             this.channel = channel;
             this.availableImageHandler = availableImageHandler;
             this.unavailableImageHandler = unavailableImageHandler;
@@ -84,14 +84,14 @@ namespace Adaptive.Aeron
     /// receive whole messages, whether or not they were fragmented, then the Subscriber
     /// should be created with a <seealso cref="FragmentAssembler"/> or a custom implementation.
     /// 
-    /// It is an application's responsibility to <seealso cref="Poll"/> the <seealso cref="Subscription"/> for new messages.
+    /// It is an application's responsibility to <seealso cref="Poll(IFragmentHandler, int)"/> the <seealso cref="Subscription"/> for new messages.
     /// 
     /// <b>Note:</b>Subscriptions are not threadsafe and should not be shared between subscribers.
     /// </summary>
     /// <seealso cref="FragmentAssembler"/>
     /// <seealso cref="ControlledFragmentHandler"/>
     /// <seealso cref="Aeron.AddSubscription(string, int)"/>
-    /// <seealso cref="Aeron.AddSubscription(string, int, AvailableImageHandler, UnavailableImageHandler)"/>
+    /// <seealso cref="Aeron.AddSubscription(string, int, Adaptive.Aeron.AvailableImageHandler, Adaptive.Aeron.UnavailableImageHandler)"/>
     public class Subscription : IDisposable
     {
         private SubscriptionFields _fields;
@@ -297,28 +297,6 @@ namespace Adaptive.Aeron
 
             return bytesConsumed;
         }
-
-        // TODO come back to this
-        ///// <summary>
-        ///// Poll the <seealso cref="Image"/>s under the subscription for available message fragments in blocks.
-        ///// <para>
-        ///// This method is useful for operations like bulk archiving a stream to file.
-        ///// 
-        ///// </para>
-        ///// </summary>
-        ///// <param name="rawBlockHandler"> to receive a block of fragments from each <seealso cref="Image"/>. </param>
-        ///// <param name="blockLengthLimit"> for each <seealso cref="Image"/> polled. </param>
-        ///// <returns> the number of bytes consumed. </returns>
-        //public long RawPoll(IRawBlockHandler rawBlockHandler, int blockLengthLimit)
-        //{
-        //    long bytesConsumed = 0;
-        //    foreach (Image image in images)
-        //    {
-        //        bytesConsumed += image.FilePoll(rawBlockHandler, blockLengthLimit);
-        //    }
-
-        //    return bytesConsumed;
-        //}
 
         /// <summary>
         /// Is this subscription connected by having at least one open publication <seealso cref="Image"/>.

--- a/src/Adaptive.Agrona.Tests/AtomicBufferTests.cs
+++ b/src/Adaptive.Agrona.Tests/AtomicBufferTests.cs
@@ -15,7 +15,6 @@
  */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
@@ -108,7 +107,6 @@ namespace Adaptive.Agrona.Tests
             buffer.CheckLimit(index);
         }
 
-#if DEBUG
         [Theory]
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void ShouldThrowExceptionWhenOutOfBounds(IAtomicBuffer buffer)
@@ -116,7 +114,6 @@ namespace Adaptive.Agrona.Tests
             const int index = BufferCapacity;
             buffer.GetByte(index);
         }
-#endif
 
         [Test]
         public void SharedBuffer()

--- a/src/Adaptive.Agrona/Adaptive.Agrona.csproj
+++ b/src/Adaptive.Agrona/Adaptive.Agrona.csproj
@@ -28,4 +28,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
     <DefineConstants>$(DefineConstants);NET45;NETFULL</DefineConstants>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="Fody" Version="3.2.16">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Virtuosity.Fody" Version="1.21.3" />
+  </ItemGroup>
 </Project>

--- a/src/Adaptive.Agrona/CacheLinePadding.cs
+++ b/src/Adaptive.Agrona/CacheLinePadding.cs
@@ -18,7 +18,9 @@ namespace Adaptive.Agrona
 {
     public struct CacheLinePadding
     {
+#pragma warning disable 649
         private long p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15;
+#pragma warning restore 649
 
         // To prevent compiler removing unused padding fields
         public override string ToString()

--- a/src/Adaptive.Agrona/Concurrent/Broadcast/CopyBroadcastReceiver.cs
+++ b/src/Adaptive.Agrona/Concurrent/Broadcast/CopyBroadcastReceiver.cs
@@ -76,11 +76,7 @@ namespace Adaptive.Agrona.Concurrent.Broadcast
         /// </summary>
         /// <param name="handler"> to be called for each message received. </param>
         /// <returns> the number of messages that have been received. </returns>
-#if DEBUG
-        public virtual int Receive(MessageHandler handler)
-#else
-        public  int Receive(MessageHandler handler)
-#endif
+        public int Receive(MessageHandler handler)
         {
             var messagesReceived = 0;
             var receiver = _receiver;

--- a/src/Adaptive.Agrona/Concurrent/Status/AtomicCounter.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/AtomicCounter.cs
@@ -61,7 +61,7 @@ namespace Adaptive.Agrona.Concurrent.Status
         /// Has this counter been closed?
         /// </summary>
         /// <returns> true if this counter has already been closed. </returns>
-        public bool IsClosed { get; private set; }
+        public virtual bool IsClosed { get; private set; }
 
         /// <summary>
         /// Perform an atomic increment that will not lose updates across threads.
@@ -151,7 +151,7 @@ namespace Adaptive.Agrona.Concurrent.Status
         /// <summary>
         /// Free the counter slot for reuse.
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (!IsClosed)
             {

--- a/src/Adaptive.Agrona/Concurrent/Status/AtomicCounter.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/AtomicCounter.cs
@@ -151,7 +151,7 @@ namespace Adaptive.Agrona.Concurrent.Status
         /// <summary>
         /// Free the counter slot for reuse.
         /// </summary>
-        public virtual void Dispose()
+        public void Dispose()
         {
             if (!IsClosed)
             {

--- a/src/Adaptive.Agrona/Concurrent/Status/CountersManager.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersManager.cs
@@ -300,7 +300,7 @@ namespace Adaptive.Agrona.Concurrent.Status
         /// <param name="labelOffset"> within the labelBuffer at which the label begins. </param>
         /// <param name="labelLength"> of the label in the labelBuffer. </param>
         /// <returns> the id allocated for the counter. </returns>
-        public virtual AtomicCounter NewCounter(
+        public AtomicCounter NewCounter(
             int typeId,
             IDirectBuffer keyBuffer,
             int keyOffset,

--- a/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
@@ -337,7 +337,7 @@ namespace Adaptive.Agrona.Concurrent.Status
         /// Get the deadline (in milliseconds) for when a given counter id may be reused.
         /// </summary>
         /// <param name="counterId"> to be read. </param>
-        /// <returns> deadline (in milliseconds) for when a given counter id may be reused or <seealso cref="#NOT_FREE_TO_REUSE"/> if
+        /// <returns> deadline (in milliseconds) for when a given counter id may be reused or <seealso cref="NOT_FREE_TO_REUSE"/> if
         /// currently in use. </returns>
         public long GetFreeForReuseDeadline(int counterId)
         {

--- a/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
@@ -128,11 +128,7 @@ namespace Adaptive.Agrona.Concurrent
             Wrap(buffer.Pointer, 0, (int) buffer.Capacity);
         }
 
-#if DEBUG
-        public virtual void Wrap(byte[] buffer)
-#else
         public void Wrap(byte[] buffer)
-#endif
         {
             if (buffer == null)
             {
@@ -151,12 +147,8 @@ namespace Adaptive.Agrona.Concurrent
             ByteArray = buffer;
             ByteBuffer = null;
         }
-
-#if DEBUG
-        public virtual void Wrap(byte[] buffer, int offset, int length)
-#else
+        
         public void Wrap(byte[] buffer, int offset, int length)
-#endif
         {
             if (buffer == null)
             {
@@ -189,12 +181,8 @@ namespace Adaptive.Agrona.Concurrent
             ByteArray = buffer;
             ByteBuffer = null;
         }
-
-#if DEBUG
-        public virtual void Wrap(IDirectBuffer buffer)
-#else
+        
         public void Wrap(IDirectBuffer buffer)
-#endif
         {
             FreeGcHandle();
             _needToFreeGcHandle = false;
@@ -205,12 +193,8 @@ namespace Adaptive.Agrona.Concurrent
             ByteArray = buffer.ByteArray;
             ByteBuffer = buffer.ByteBuffer;
         }
-
-#if DEBUG
-        public virtual void Wrap(ByteBuffer buffer)
-#else
+        
         public void Wrap(ByteBuffer buffer)
-#endif
         {
             FreeGcHandle();
             _needToFreeGcHandle = false;
@@ -221,12 +205,8 @@ namespace Adaptive.Agrona.Concurrent
             ByteArray = null;
             ByteBuffer = buffer;
         }
-
-#if DEBUG
-        public virtual void Wrap(IDirectBuffer buffer, int offset, int length)
-#else
+        
         public void Wrap(IDirectBuffer buffer, int offset, int length)
-#endif
         {
 #if SHOULD_BOUNDS_CHECK
             int bufferCapacity = buffer.Capacity;
@@ -252,11 +232,7 @@ namespace Adaptive.Agrona.Concurrent
             ByteBuffer = buffer.ByteBuffer;
         }
 
-#if DEBUG
-        public virtual void Wrap(IntPtr pointer, int length)
-#else
         public void Wrap(IntPtr pointer, int length)
-#endif
         {
             FreeGcHandle();
 
@@ -268,12 +244,8 @@ namespace Adaptive.Agrona.Concurrent
             ByteBuffer = null;
             ByteArray = null;
         }
-
-#if DEBUG
-        public virtual void Wrap(IntPtr pointer, int offset, int length)
-#else
+        
         public void Wrap(IntPtr pointer, int offset, int length)
-#endif
         {
             FreeGcHandle();
 
@@ -285,33 +257,21 @@ namespace Adaptive.Agrona.Concurrent
             ByteBuffer = null;
             ByteArray = null;
         }
-
-#if DEBUG
-        public virtual IntPtr BufferPointer => new IntPtr(_pBuffer);
-#else
+        
         public IntPtr BufferPointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return new IntPtr(_pBuffer); }
         }
-#endif
 
         public byte[] ByteArray { get; private set; }
 
         public ByteBuffer ByteBuffer { get; private set; }
-
-#if DEBUG
-        public virtual int Capacity { get; private set; }
-#else
+        
         public int Capacity { get; private set; }
-#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void SetMemory(int index, int length, byte value)
-#else
         public void SetMemory(int index, int length, byte value)
-#endif
         {
             BoundsCheck0(index, length);
             // TODO PERF Naive implementation, we should not write byte by byte, this is slow
@@ -323,11 +283,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void CheckLimit(int limit)
-#else
         public void CheckLimit(int limit)
-#endif
         {
             if (limit > Capacity)
             {
@@ -338,11 +294,7 @@ namespace Adaptive.Agrona.Concurrent
         public bool IsExpandable => false;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void VerifyAlignment()
-#else
         public void VerifyAlignment()
-#endif
         {
             var address = new IntPtr(_pBuffer).ToInt64();
             if (0 != (address & (ALIGNMENT - 1)))
@@ -371,22 +323,14 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutLong(int index, long value)
-#else
         public void PutLong(int index, long value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
             *(long*) (_pBuffer + index) = value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutLong(int index, long value, ByteOrder byteOrder)
-#else
         public void PutLong(int index, long value, ByteOrder byteOrder)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
 
@@ -395,11 +339,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual long GetLongVolatile(int index)
-#else
         public long GetLongVolatile(int index)
-#endif
         {
 #if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
@@ -408,11 +348,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutLongVolatile(int index, long value)
-#else
         public void PutLongVolatile(int index, long value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
 
@@ -420,11 +356,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutLongOrdered(int index, long value)
-#else
         public void PutLongOrdered(int index, long value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
 
@@ -432,11 +364,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual long AddLongOrdered(int index, long increment)
-#else
         public long AddLongOrdered(int index, long increment)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
 
@@ -447,11 +375,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual bool CompareAndSetLong(int index, long expectedValue, long updateValue)
-#else
         public bool CompareAndSetLong(int index, long expectedValue, long updateValue)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
 
@@ -461,11 +385,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual long GetAndAddLong(int index, long delta)
-#else
         public long GetAndAddLong(int index, long delta)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_LONG);
 
@@ -481,11 +401,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int GetInt(int index)
-#else
         public int GetInt(int index)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
 
@@ -502,11 +418,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutInt(int index, int value)
-#else
         public void PutInt(int index, int value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
             *(int*) (_pBuffer + index) = value;
@@ -523,11 +435,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int GetIntVolatile(int index)
-#else
         public int GetIntVolatile(int index)
-#endif
         {
 #if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
@@ -536,11 +444,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutIntVolatile(int index, int value)
-#else
         public void PutIntVolatile(int index, int value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
 
@@ -548,11 +452,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutIntOrdered(int index, int value)
-#else
         public void PutIntOrdered(int index, int value)
-#endif
         {
 #if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
@@ -561,11 +461,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int AddIntOrdered(int index, int increment)
-#else
         public int AddIntOrdered(int index, int increment)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
 
@@ -576,11 +472,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual bool CompareAndSetInt(int index, int expectedValue, int updateValue)
-#else
         public bool CompareAndSetInt(int index, int expectedValue, int updateValue)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
 
@@ -590,11 +482,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int GetAndAddInt(int index, int delta)
-#else
         public int GetAndAddInt(int index, int delta)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_INT);
 
@@ -623,11 +511,7 @@ namespace Adaptive.Agrona.Concurrent
         //    }
         //}
 
-#if DEBUG
-        //public virtual void PutDouble(int index, double value, ByteOrder byteOrder)
-#else
-//public void PutDouble(int index, double value, ByteOrder byteOrder)
-#endif
+        //public void PutDouble(int index, double value, ByteOrder byteOrder)
         //{
         //    if (SHOULD_BOUNDS_CHECK)
         //    {
@@ -646,11 +530,7 @@ namespace Adaptive.Agrona.Concurrent
         //}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual double GetDouble(int index)
-#else
         public double GetDouble(int index)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_DOUBLE);
 
@@ -658,11 +538,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutDouble(int index, double value)
-#else
         public void PutDouble(int index, double value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_DOUBLE);
 
@@ -672,11 +548,7 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual float GetFloat(int index)
-#else
         public float GetFloat(int index)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_FLOAT);
 
@@ -684,11 +556,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutFloat(int index, float value)
-#else
         public void PutFloat(int index, float value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_FLOAT);
 
@@ -698,11 +566,7 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual short GetShort(int index)
-#else
         public short GetShort(int index)
-#endif
         {
 #if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
@@ -711,11 +575,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual short GetShort(int index, ByteOrder byteOrder)
-#else
         public short GetShort(int index, ByteOrder byteOrder)
-#endif
         {
 #if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
@@ -724,11 +584,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutShort(int index, short value)
-#else
         public void PutShort(int index, short value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
 
@@ -736,11 +592,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutShort(int index, short value, ByteOrder byteOrder)
-#else
         public void PutShort(int index, short value, ByteOrder byteOrder)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
 
@@ -748,11 +600,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual short GetShortVolatile(int index)
-#else
         public short GetShortVolatile(int index)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
 
@@ -760,11 +608,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutShortVolatile(int index, short value)
-#else
         public void PutShortVolatile(int index, short value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_SHORT);
 
@@ -774,11 +618,7 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual byte GetByte(int index)
-#else
         public byte GetByte(int index)
-#endif
         {
             BoundsCheck(index);
 
@@ -786,11 +626,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutByte(int index, byte value)
-#else
         public void PutByte(int index, byte value)
-#endif
         {
             BoundsCheck(index);
 
@@ -798,11 +634,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual byte GetByteVolatile(int index)
-#else
         public byte GetByteVolatile(int index)
-#endif
         {
             BoundsCheck(index);
 
@@ -810,11 +642,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutByteVolatile(int index, byte value)
-#else
         public void PutByteVolatile(int index, byte value)
-#endif
         {
             BoundsCheck(index);
 
@@ -824,21 +652,13 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void GetBytes(int index, byte[] dst)
-#else
         public void GetBytes(int index, byte[] dst)
-#endif
         {
             GetBytes(index, dst, 0, dst.Length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void GetBytes(int index, byte[] dst, int offset, int length)
-#else
         public void GetBytes(int index, byte[] dst, int offset, int length)
-#endif
         {
             if (length == 0) return;
 
@@ -853,31 +673,19 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void GetBytes(int index, IMutableDirectBuffer dstBuffer, int dstIndex, int length)
-#else
         public void GetBytes(int index, IMutableDirectBuffer dstBuffer, int dstIndex, int length)
-#endif
         {
             dstBuffer.PutBytes(dstIndex, this, index, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutBytes(int index, byte[] src)
-#else
         public void PutBytes(int index, byte[] src)
-#endif
         {
             PutBytes(index, src, 0, src.Length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutBytes(int index, byte[] src, int offset, int length)
-#else
         public void PutBytes(int index, byte[] src, int offset, int length)
-#endif
         {
             if (length == 0)
             {
@@ -895,11 +703,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutBytes(int index, IDirectBuffer srcBuffer, int srcIndex, int length)
-#else
         public void PutBytes(int index, IDirectBuffer srcBuffer, int srcIndex, int length)
-#endif
         {
             if (length == 0)
             {
@@ -917,11 +721,7 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual char GetChar(int index)
-#else
         public char GetChar(int index)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_CHAR);
 
@@ -929,11 +729,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void PutChar(int index, char value)
-#else
         public void PutChar(int index, char value)
-#endif
         {
             BoundsCheck0(index, BitUtil.SIZE_OF_CHAR);
 
@@ -947,11 +743,7 @@ namespace Adaptive.Agrona.Concurrent
         //    return (char)Volatile.Read(ref *(short*)(_pBuffer + index));
         //}
 
-#if DEBUG
-        //public virtual void PutCharVolatile(int index, char value)
-#else
-//public void PutCharVolatile(int index, char value)
-#endif
+        //public void PutCharVolatile(int index, char value)
         //{
         //    BoundsCheck0(index, BitUtil.SIZE_OF_CHAR);
 
@@ -961,11 +753,7 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual string GetStringUtf8(int index)
-#else
         public string GetStringUtf8(int index)
-#endif
         {
             var length = GetInt(index);
 
@@ -973,11 +761,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual string GetStringAscii(int index)
-#else
         public string GetStringAscii(int index)
-#endif
         {
             var length = GetInt(index);
 
@@ -985,11 +769,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual string GetStringUtf8(int index, int length)
-#else
         public string GetStringUtf8(int index, int length)
-#endif
         {
             var stringInBytes = new byte[length];
             GetBytes(index + BitUtil.SIZE_OF_INT, stringInBytes);
@@ -998,11 +778,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual string GetStringAscii(int index, int length)
-#else
         public string GetStringAscii(int index, int length)
-#endif
         {
             var stringInBytes = new byte[length];
             GetBytes(index + BitUtil.SIZE_OF_INT, stringInBytes);
@@ -1025,8 +801,7 @@ namespace Adaptive.Agrona.Concurrent
         public int PutStringWithoutLengthAscii(int index, string value)
         {
             int length = value?.Length ?? 0;
-
-
+            
 #if SHOULD_BOUNDS_CHECK
             BoundsCheck0(index, length);
 #endif
@@ -1101,11 +876,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual string GetStringWithoutLengthUtf8(int index, int length)
-#else
         public string GetStringWithoutLengthUtf8(int index, int length)
-#endif
         {
             var stringInBytes = new byte[length];
             GetBytes(index, stringInBytes);
@@ -1114,11 +885,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int PutStringWithoutLengthUtf8(int index, string value)
-#else
         public int PutStringWithoutLengthUtf8(int index, string value)
-#endif
         {
             var bytes = value == null
                 ? BufferUtil.NullBytes
@@ -1154,11 +921,7 @@ namespace Adaptive.Agrona.Concurrent
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual void BoundsCheck(int index, int length)
-#else
         public void BoundsCheck(int index, int length)
-#endif
         {
             BoundsCheck0(index, length);
         }
@@ -1166,11 +929,7 @@ namespace Adaptive.Agrona.Concurrent
         ///////////////////////////////////////////////////////////////////////////
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if DEBUG
-        public virtual int CompareTo(IDirectBuffer that)
-#else
         public int CompareTo(IDirectBuffer that)
-#endif
         {
             var thisCapacity = this.Capacity;
             var thatCapacity = that.Capacity;
@@ -1200,11 +959,7 @@ namespace Adaptive.Agrona.Concurrent
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         /// <filterpriority>2</filterpriority>
-#if DEBUG
-        public virtual void Dispose()
-#else
         public void Dispose()
-#endif
         {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/src/Adaptive.Agrona/FodyWeavers.xml
+++ b/src/Adaptive.Agrona/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+  <Virtuosity/>
+</Weavers>

--- a/src/Adaptive.Agrona/MarkFile.cs
+++ b/src/Adaptive.Agrona/MarkFile.cs
@@ -154,7 +154,7 @@ namespace Adaptive.Agrona
             this.timestampFieldOffset = timestampFieldOffset;
         }
 
-        public virtual bool IsClosed()
+        public bool IsClosed()
         {
             return isClosed;
         }
@@ -172,57 +172,57 @@ namespace Adaptive.Agrona
             }
         }
 
-        public virtual void SignalReady(int version)
+        public void SignalReady(int version)
         {
             buffer.PutIntOrdered(versionFieldOffset, version);
         }
 
-        public virtual int VersionVolatile()
+        public int VersionVolatile()
         {
             return buffer.GetIntVolatile(versionFieldOffset);
         }
 
-        public virtual int VersionWeak()
+        public int VersionWeak()
         {
             return buffer.GetInt(versionFieldOffset);
         }
 
-        public virtual void TimestampOrdered(long timestamp)
+        public void TimestampOrdered(long timestamp)
         {
             buffer.PutLongOrdered(timestampFieldOffset, timestamp);
         }
 
-        public virtual long TimestampVolatile()
+        public long TimestampVolatile()
         {
             return buffer.GetLongVolatile(timestampFieldOffset);
         }
 
-        public virtual long TimestampWeak()
+        public long TimestampWeak()
         {
             return buffer.GetLong(timestampFieldOffset);
         }
 
-        public virtual void DeleteDirectory(bool ignoreFailures)
+        public void DeleteDirectory(bool ignoreFailures)
         {
             IoUtil.Delete(parentDir, ignoreFailures);
         }
 
-        public virtual DirectoryInfo CncDirectory()
+        public DirectoryInfo CncDirectory()
         {
             return parentDir;
         }
 
-        public virtual FileInfo CncFileName()
+        public FileInfo CncFileName()
         {
             return markFile;
         }
 
-        public virtual MappedByteBuffer MappedByteBuffer()
+        public MappedByteBuffer MappedByteBuffer()
         {
             return mappedBuffer;
         }
 
-        public virtual UnsafeBuffer Buffer()
+        public UnsafeBuffer Buffer()
         {
             return buffer;
         }

--- a/src/Adaptive.Agrona/MarkFile.cs
+++ b/src/Adaptive.Agrona/MarkFile.cs
@@ -28,7 +28,7 @@ namespace Adaptive.Agrona
         /// Create a CnC directory and file if none present. Checking if an active CnC file exists and is active. Old CnC
         /// file is deleted and recreated if not active.
         /// 
-        /// Total length of CnC file will be mapped until <seealso cref="#close()"/> is called.
+        /// Total length of CnC file will be mapped until <seealso cref="Dispose"/> is called.
         /// </summary>
         /// <param name="directory">             for the CnC file </param>
         /// <param name="filename">              of the CnC file </param>
@@ -62,7 +62,7 @@ namespace Adaptive.Agrona
         /// Create a CnC file if none present. Checking if an active CnC file exists and is active. Existing CnC file
         /// is used if not active.
         /// 
-        /// Total length of CnC file will be mapped until <seealso cref="#close()"/> is called.
+        /// Total length of CnC file will be mapped until <seealso cref="Dispose"/> is called.
         /// </summary>
         /// <param name="markFile">               to use </param>
         /// <param name="shouldPreExist">        or not </param>
@@ -92,7 +92,7 @@ namespace Adaptive.Agrona
         /// <summary>
         /// Map a pre-existing CnC file if one present and is active.
         /// 
-        /// Total length of CnC file will be mapped until <seealso cref="#close()"/> is called.
+        /// Total length of CnC file will be mapped until <seealso cref="Dispose"/> is called.
         /// </summary>
         /// <param name="directory">             for the CnC file </param>
         /// <param name="filename">              of the CnC file </param>
@@ -119,7 +119,7 @@ namespace Adaptive.Agrona
         /// <summary>
         /// Manage a CnC file given a mapped file and offsets of version and timestamp.
         /// 
-        /// If mappedCncBuffer is not null, then it will be unmapped upon <seealso cref="#close()"/>.
+        /// If mappedCncBuffer is not null, then it will be unmapped upon <seealso cref="Dispose"/>.
         /// </summary>
         /// <param name="mappedBuffer">      for the CnC fields </param>
         /// <param name="versionFieldOffset">   for the version field </param>

--- a/src/Adaptive.Agrona/Util/IntUtil.cs
+++ b/src/Adaptive.Agrona/Util/IntUtil.cs
@@ -83,8 +83,8 @@ namespace Adaptive.Agrona.Util
         /// <para>Note that this method is closely related to the logarithm base 2.
         /// For all positive {@code int} values x:
         /// <ul>
-        /// <li>floor(log<sub>2</sub>(x)) = {@code 31 - numberOfLeadingZeros(x)}
-        /// <li>ceil(log<sub>2</sub>(x)) = {@code 32 - numberOfLeadingZeros(x - 1)}
+        /// <li>floor(log<sub>2</sub>(x)) = {@code 31 - numberOfLeadingZeros(x)}</li>
+        /// <li>ceil(log<sub>2</sub>(x)) = {@code 32 - numberOfLeadingZeros(x - 1)}</li>
         /// </ul>
         /// 
         /// </para>

--- a/src/Adaptive.Archiver/AeronArchive.cs
+++ b/src/Adaptive.Archiver/AeronArchive.cs
@@ -15,7 +15,7 @@ namespace Adaptive.Archiver
     /// <seealso cref="RecordingDescriptorPoller"/> may be used directly if a more asynchronous interaction is required.
     /// </para>
     /// <para>
-    /// Note: This class is threadsafe but the lock can be elided for single threaded access via <seealso cref="Aeron.Context#lock(Lock)"/>
+    /// Note: This class is threadsafe but the lock can be elided for single threaded access via <seealso cref="Adaptive.Aeron.Aeron.Context.ClientLock(Adaptive.Agrona.Concurrent.ILock)"/>
     /// being set to <seealso cref="NoOpLock"/>.
     /// </para>
     /// </summary>
@@ -139,7 +139,7 @@ namespace Adaptive.Archiver
         }
 
         /// <summary>
-        /// Connect to an Aeron archive using a default <seealso cref="Aeron.Context"/>. This will create a control session.
+        /// Connect to an Aeron archive using a default <seealso cref="Adaptive.Aeron.Aeron.Context"/>. This will create a control session.
         /// </summary>
         /// <returns> the newly created Aeron Archive client. </returns>
         public static AeronArchive Connect()
@@ -148,10 +148,10 @@ namespace Adaptive.Archiver
         }
 
         /// <summary>
-        /// Connect to an Aeron archive by providing a <seealso cref="Aeron.Context"/>. This will create a control session.
+        /// Connect to an Aeron archive by providing a <seealso cref="Adaptive.Aeron.Aeron.Context"/>. This will create a control session.
         /// <para>
-        /// Before connecting <seealso cref="Aeron.Context#conclude()"/> will be called.
-        /// If an exception occurs then <seealso cref="Aeron.Context#close()"/> will be called.
+        /// Before connecting <seealso cref="Adaptive.Aeron.Aeron.Context.Conclude()"/> will be called.
+        /// If an exception occurs then <seealso cref="Adaptive.Aeron.Aeron.Context.Dispose()"/> will be called.
         /// 
         /// </para>
         /// </summary>
@@ -215,9 +215,9 @@ namespace Adaptive.Archiver
 
 
         /// <summary>
-        /// Get the <seealso cref="Aeron.Context"/> used to connect this archive client.
+        /// Get the <seealso cref="Adaptive.Aeron.Aeron.Context"/> used to connect this archive client.
         /// </summary>
-        /// <returns> the <seealso cref="Aeron.Context"/> used to connect this archive client. </returns>
+        /// <returns> the <seealso cref="Adaptive.Aeron.Aeron.Context"/> used to connect this archive client. </returns>
         public Context Ctx()
         {
             return context;
@@ -314,7 +314,7 @@ namespace Adaptive.Archiver
 
         /// <summary>
         /// Add a <seealso cref="Publication"/> and set it up to be recorded. If this is not the first,
-        /// i.e. <seealso cref="Publication#isOriginal()"/> is true,  then an <seealso cref="ArchiveException"/>
+        /// i.e. <seealso cref="Publication.IsOriginal"/> is true,  then an <seealso cref="ArchiveException"/>
         /// will be thrown and the recording not initiated.
         /// <para>
         /// This is a sessionId specific recording.
@@ -498,8 +498,8 @@ namespace Adaptive.Archiver
 
         /// <summary>
         /// Stop recording for a subscriptionId that has been returned from
-        /// <seealso cref="#startRecording(String, int, SourceLocation)"/> or
-        /// <seealso cref="#extendRecording(long, String, int, SourceLocation)"/>.
+        /// <seealso cref="StartRecording(String, int, SourceLocation)"/> or
+        /// <seealso cref="ExtendRecording(long, String, int, SourceLocation)"/>.
         /// </summary>
         /// <param name="subscriptionId"> the subscription was registered with for the recording. </param>
         public void StopRecording(long subscriptionId)
@@ -761,7 +761,7 @@ namespace Adaptive.Archiver
         /// Get the position recorded for an active recording.
         /// </summary>
         /// <param name="recordingId"> of the active recording for which the position is required. </param>
-        /// <returns> the recorded position for the active recording or <seealso cref="#NULL_POSITION"/> if recording not active. </returns>
+        /// <returns> the recorded position for the active recording or <seealso cref="NULL_POSITION"/> if recording not active. </returns>
         public long GetRecordingPosition(long recordingId)
         {
             _lock.Lock();
@@ -814,7 +814,7 @@ namespace Adaptive.Archiver
         /// <param name="channel">        for a contains match on the stripped channel stored with the archive descriptor </param>
         /// <param name="streamId">       of the recording to match. </param>
         /// <param name="sessionId">      of the recording to match. </param>
-        /// <returns> the recordingId if found otherwise <seealso cref="Aeron.NULL_VALUE"/> if not found. </returns>
+        /// <returns> the recordingId if found otherwise <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if not found. </returns>
         public long FindLastMatchingRecording(long minRecordingId, string channel, int streamId, int sessionId)
         {
             _lock.Lock();
@@ -1162,7 +1162,7 @@ namespace Adaptive.Archiver
             /// The timeout in nanoseconds to wait for a message.
             /// </summary>
             /// <returns> timeout in nanoseconds to wait for a message. </returns>
-            /// <seealso cref= #MESSAGE_TIMEOUT_PROP_NAME </seealso>
+            /// <seealso cref="MESSAGE_TIMEOUT_PROP_NAME"></seealso>
             public static long MessageTimeoutNs()
             {
                 return Config.GetDurationInNanos(MESSAGE_TIMEOUT_PROP_NAME, MESSAGE_TIMEOUT_DEFAULT_NS);
@@ -1193,95 +1193,95 @@ namespace Adaptive.Archiver
             /// MTU length to be used for control request and response streams.
             /// </summary>
             /// <returns> MTU length to be used for control request and response streams. </returns>
-            /// <seealso cref= #CONTROL_MTU_LENGTH_PARAM_NAME </seealso>
+            /// <seealso cref="CONTROL_MTU_LENGTH_PARAM_NAME"></seealso>
             public static int ControlMtuLength()
             {
                 return Config.GetSizeAsInt(CONTROL_MTU_LENGTH_PARAM_NAME, CONTROL_MTU_LENGTH_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#CONTROL_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="CONTROL_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#CONTROL_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="CONTROL_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string ControlChannel()
             {
                 return Config.GetProperty(CONTROL_CHANNEL_PROP_NAME, CONTROL_CHANNEL_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#CONTROL_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_STREAM_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="CONTROL_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_STREAM_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#CONTROL_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="CONTROL_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int ControlStreamId()
             {
                 return Config.GetInteger(CONTROL_STREAM_ID_PROP_NAME, CONTROL_STREAM_ID_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#LOCAL_CONTROL_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="LOCAL_CONTROL_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#LOCAL_CONTROL_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#LOCAL_CONTROL_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="LOCAL_CONTROL_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="LOCAL_CONTROL_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string LocalControlChannel()
             {
                 return Config.GetProperty(LOCAL_CONTROL_CHANNEL_PROP_NAME, LOCAL_CONTROL_CHANNEL_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#LOCAL_CONTROL_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#LOCAL_CONTROL_STREAM_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="LOCAL_CONTROL_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="LOCAL_CONTROL_STREAM_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#LOCAL_CONTROL_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#LOCAL_CONTROL_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="LOCAL_CONTROL_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="LOCAL_CONTROL_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int LocalControlStreamId()
             {
                 return Config.GetInteger(LOCAL_CONTROL_STREAM_ID_PROP_NAME, LOCAL_CONTROL_STREAM_ID_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#CONTROL_RESPONSE_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_RESPONSE_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="CONTROL_RESPONSE_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_RESPONSE_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#CONTROL_RESPONSE_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_RESPONSE_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="CONTROL_RESPONSE_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_RESPONSE_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string ControlResponseChannel()
             {
                 return Config.GetProperty(CONTROL_RESPONSE_CHANNEL_PROP_NAME, CONTROL_RESPONSE_CHANNEL_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#CONTROL_RESPONSE_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_RESPONSE_STREAM_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="CONTROL_RESPONSE_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_RESPONSE_STREAM_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#CONTROL_RESPONSE_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#CONTROL_RESPONSE_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="CONTROL_RESPONSE_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="CONTROL_RESPONSE_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int ControlResponseStreamId()
             {
                 return Config.GetInteger(CONTROL_RESPONSE_STREAM_ID_PROP_NAME, CONTROL_RESPONSE_STREAM_ID_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#RECORDING_EVENTS_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#RECORDING_EVENTS_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="RECORDING_EVENTS_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="RECORDING_EVENTS_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#RECORDING_EVENTS_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#RECORDING_EVENTS_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="RECORDING_EVENTS_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="RECORDING_EVENTS_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string RecordingEventsChannel()
             {
                 return Config.GetProperty(RECORDING_EVENTS_CHANNEL_PROP_NAME, RECORDING_EVENTS_CHANNEL_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#RECORDING_EVENTS_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#RECORDING_EVENTS_STREAM_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="RECORDING_EVENTS_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="RECORDING_EVENTS_STREAM_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#RECORDING_EVENTS_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#RECORDING_EVENTS_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="RECORDING_EVENTS_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="RECORDING_EVENTS_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int RecordingEventsStreamId()
             {
                 return Config.GetInteger(RECORDING_EVENTS_STREAM_ID_PROP_NAME, RECORDING_EVENTS_STREAM_ID_DEFAULT);
@@ -1353,7 +1353,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="messageTimeoutNs"> to wait for sending or receiving a message. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#MESSAGE_TIMEOUT_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.MESSAGE_TIMEOUT_PROP_NAME"/>
             public Context MessageTimeoutNs(long messageTimeoutNs)
             {
                 this.messageTimeoutNs = messageTimeoutNs;
@@ -1364,7 +1364,7 @@ namespace Adaptive.Archiver
             /// The message timeout in nanoseconds to wait for sending or receiving a message.
             /// </summary>
             /// <returns> the message timeout in nanoseconds to wait for sending or receiving a message. </returns>
-            /// <seealso cref= Configuration#MESSAGE_TIMEOUT_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.MESSAGE_TIMEOUT_PROP_NAME"/>
             public long MessageTimeoutNs()
             {
                 return messageTimeoutNs;
@@ -1389,7 +1389,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="recordingEventsChannel"> channel URI on which the recording events publication will publish. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= io.aeron.CommonContext#MDC_CONTROL_PARAM_NAME </seealso>
+            /// <seealso cref="Adaptive.Aeron.Aeron.Context.MDC_CONTROL_PARAM_NAME"/>
             public Context RecordingEventsChannel(string recordingEventsChannel)
             {
                 this.recordingEventsChannel = recordingEventsChannel;
@@ -1421,7 +1421,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="channel"> parameter for the control request channel. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#CONTROL_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_CHANNEL_PROP_NAME"></seealso>
             public Context ControlRequestChannel(string channel)
             {
                 controlRequestChannel = channel;
@@ -1432,7 +1432,7 @@ namespace Adaptive.Archiver
             /// Get the channel parameter for the control request channel.
             /// </summary>
             /// <returns> the channel parameter for the control request channel. </returns>
-            /// <seealso cref= Configuration#CONTROL_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_CHANNEL_PROP_NAME"></seealso>
             public string ControlRequestChannel()
             {
                 return controlRequestChannel;
@@ -1443,7 +1443,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="streamId"> for the control request channel. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= Configuration#CONTROL_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_STREAM_ID_PROP_NAME"></seealso>
             public Context ControlRequestStreamId(int streamId)
             {
                 controlRequestStreamId = streamId;
@@ -1454,7 +1454,7 @@ namespace Adaptive.Archiver
             /// Get the stream id for the control request channel.
             /// </summary>
             /// <returns> the stream id for the control request channel. </returns>
-            /// <seealso cref= Configuration#CONTROL_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_STREAM_ID_PROP_NAME"></seealso>
             public int ControlRequestStreamId()
             {
                 return controlRequestStreamId;
@@ -1465,7 +1465,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="channel"> parameter for the control response channel. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#CONTROL_RESPONSE_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_RESPONSE_CHANNEL_PROP_NAME"></seealso>s
             public Context ControlResponseChannel(string channel)
             {
                 controlResponseChannel = channel;
@@ -1476,7 +1476,7 @@ namespace Adaptive.Archiver
             /// Get the channel parameter for the control response channel.
             /// </summary>
             /// <returns> the channel parameter for the control response channel. </returns>
-            /// <seealso cref= Configuration#CONTROL_RESPONSE_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_RESPONSE_CHANNEL_PROP_NAME"></seealso>
             public string ControlResponseChannel()
             {
                 return controlResponseChannel;
@@ -1487,7 +1487,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="streamId"> for the control response channel. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= Configuration#CONTROL_RESPONSE_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_RESPONSE_STREAM_ID_PROP_NAME"></seealso>
             public Context ControlResponseStreamId(int streamId)
             {
                 controlResponseStreamId = streamId;
@@ -1498,7 +1498,7 @@ namespace Adaptive.Archiver
             /// Get the stream id for the control response channel.
             /// </summary>
             /// <returns> the stream id for the control response channel. </returns>
-            /// <seealso cref= Configuration#CONTROL_RESPONSE_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_RESPONSE_STREAM_ID_PROP_NAME"></seealso>
             public int ControlResponseStreamId()
             {
                 return controlResponseStreamId;
@@ -1531,7 +1531,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="controlTermBufferLength"> for the control stream. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#CONTROL_TERM_BUFFER_LENGTH_PARAM_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_TERM_BUFFER_LENGTH_PARAM_NAME"></seealso>
             public Context ControlTermBufferLength(int controlTermBufferLength)
             {
                 this.controlTermBufferLength = controlTermBufferLength;
@@ -1542,7 +1542,7 @@ namespace Adaptive.Archiver
             /// Get the term buffer length for the control streams.
             /// </summary>
             /// <returns> the term buffer length for the control streams. </returns>
-            /// <seealso cref= Configuration#CONTROL_TERM_BUFFER_LENGTH_PARAM_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_TERM_BUFFER_LENGTH_PARAM_NAME"></seealso>
             public int ControlTermBufferLength()
             {
                 return controlTermBufferLength;
@@ -1553,7 +1553,7 @@ namespace Adaptive.Archiver
             /// </summary>
             /// <param name="controlMtuLength"> for the control streams. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#CONTROL_MTU_LENGTH_PARAM_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_MTU_LENGTH_PARAM_NAME"></seealso>
             public Context ControlMtuLength(int controlMtuLength)
             {
                 this.controlMtuLength = controlMtuLength;
@@ -1564,14 +1564,14 @@ namespace Adaptive.Archiver
             /// Get the MTU length for the control steams.
             /// </summary>
             /// <returns> the MTU length for the control steams. </returns>
-            /// <seealso cref= Configuration#CONTROL_MTU_LENGTH_PARAM_NAME </seealso>
+            /// <seealso cref="Configuration.CONTROL_MTU_LENGTH_PARAM_NAME"></seealso>
             public int ControlMtuLength()
             {
                 return controlMtuLength;
             }
 
             /// <summary>
-            /// Set the <seealso cref="IdleStrategy"/> used when waiting for responses.
+            /// Set the <seealso cref="IIdleStrategy"/> used when waiting for responses.
             /// </summary>
             /// <param name="idleStrategy"> used when waiting for responses. </param>
             /// <returns> this for a fluent API. </returns>
@@ -1582,9 +1582,9 @@ namespace Adaptive.Archiver
             }
 
             /// <summary>
-            /// Get the <seealso cref="IdleStrategy"/> used when waiting for responses.
+            /// Get the <seealso cref="IIdleStrategy"/> used when waiting for responses.
             /// </summary>
-            /// <returns> the <seealso cref="IdleStrategy"/> used when waiting for responses. </returns>
+            /// <returns> the <seealso cref="IIdleStrategy"/> used when waiting for responses. </returns>
             public IIdleStrategy IdleStrategy()
             {
                 return idleStrategy;
@@ -1613,14 +1613,14 @@ namespace Adaptive.Archiver
             /// <summary>
             /// <seealso cref="Adaptive.Aeron.Aeron"/> client for communicating with the local Media Driver.
             /// <para>
-            /// This client will be closed when the <seealso cref="AeronArchive#close()"/> or <seealso cref="#close()"/> methods are called if
-            /// <seealso cref="#ownsAeronClient()"/> is true.
+            /// This client will be closed when the <seealso cref="AeronArchive.Dispose()"/> or <seealso cref="Dispose()"/> methods are called if
+            /// <seealso cref="OwnsAeronClient()"/> is true.
             /// 
             /// </para>
             /// </summary>
             /// <param name="aeron"> client for communicating with the local Media Driver. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Aeron#connect() </seealso>
+            /// <seealso cref="Adaptive.Aeron.Aeron.Connect()"></seealso>
             public Context AeronClient(Aeron.Aeron aeron)
             {
                 this.aeron = aeron;
@@ -1630,8 +1630,8 @@ namespace Adaptive.Archiver
             /// <summary>
             /// <seealso cref="Adaptive.Aeron.Aeron"/> client for communicating with the local Media Driver.
             /// <para>
-            /// If not provided then a default will be established during <seealso cref="#conclude()"/> by calling
-            /// <seealso cref="Adaptive.Aeron.Aeron#connect()"/>.
+            /// If not provided then a default will be established during <seealso cref="Conclude()"/> by calling
+            /// <seealso cref="Adaptive.Aeron.Aeron.Connect()"/>.
             /// 
             /// </para>
             /// </summary>
@@ -1642,9 +1642,9 @@ namespace Adaptive.Archiver
             }
 
             /// <summary>
-            /// Does this context own the <seealso cref="#aeron()"/> client and this takes responsibility for closing it?
+            /// Does this context own the <seealso cref="AeronClient()"/> client and this takes responsibility for closing it?
             /// </summary>
-            /// <param name="ownsAeronClient"> does this context own the <seealso cref="#aeron()"/> client. </param>
+            /// <param name="ownsAeronClient"> does this context own the <seealso cref="AeronClient()"/> client. </param>
             /// <returns> this for a fluent API. </returns>
             public Context OwnsAeronClient(bool ownsAeronClient)
             {
@@ -1653,9 +1653,9 @@ namespace Adaptive.Archiver
             }
 
             /// <summary>
-            /// Does this context own the <seealso cref="#aeron()"/> client and this takes responsibility for closing it?
+            /// Does this context own the <seealso cref="AeronClient()"/> client and this takes responsibility for closing it?
             /// </summary>
-            /// <returns> does this context own the <seealso cref="#aeron()"/> client and this takes responsibility for closing it? </returns>
+            /// <returns> does this context own the <seealso cref="AeronClient()"/> client and this takes responsibility for closing it? </returns>
             public bool OwnsAeronClient()
             {
                 return ownsAeronClient;
@@ -1689,7 +1689,7 @@ namespace Adaptive.Archiver
             /// <summary>
             /// Close the context and free applicable resources.
             /// <para>
-            /// If <seealso cref="#ownsAeronClient()"/> is true then the <seealso cref="#aeron()"/> client will be closed.
+            /// If <seealso cref="OwnsAeronClient()"/> is true then the <seealso cref="AeronClient()"/> client will be closed.
             /// </para>
             /// </summary>
             public void Dispose()

--- a/src/Adaptive.Archiver/AeronArchive.cs
+++ b/src/Adaptive.Archiver/AeronArchive.cs
@@ -291,7 +291,7 @@ namespace Adaptive.Archiver
         /// To check for an error response without raising an exception then try <seealso cref="PollForErrorResponse()"/>.
         /// </summary>
         ///  <seealso cref="PollForErrorResponse()"/>
-        public virtual void CheckForErrorResponse()
+        public void CheckForErrorResponse()
         {
             _lock.Lock();
             try

--- a/src/Adaptive.Archiver/ArchiveProxy.cs
+++ b/src/Adaptive.Archiver/ArchiveProxy.cs
@@ -77,7 +77,7 @@ namespace Adaptive.Archiver
         /// Get the <seealso cref="Publication"/> used for sending control messages.
         /// </summary>
         /// <returns> the <seealso cref="Publication"/> used for sending control messages. </returns>
-        public virtual Publication Pub()
+        public Publication Pub()
         {
             return publication;
         }
@@ -89,7 +89,7 @@ namespace Adaptive.Archiver
         /// <param name="responseStreamId"> for the control message responses. </param>
         /// <param name="correlationId">    for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool Connect(string responseChannel, int responseStreamId, long correlationId)
+        public bool Connect(string responseChannel, int responseStreamId, long correlationId)
         {
             connectRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -129,7 +129,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">      for this request. </param>
         /// <param name="aeronClientInvoker"> for aeron client conductor thread. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool Connect(string responseChannel, int responseStreamId, long correlationId, AgentInvoker aeronClientInvoker)
+        public bool Connect(string responseChannel, int responseStreamId, long correlationId, AgentInvoker aeronClientInvoker)
         {
             connectRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -145,7 +145,7 @@ namespace Adaptive.Archiver
         /// </summary>
         /// <param name="controlSessionId"> with the archive. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool CloseSession(long controlSessionId)
+        public bool CloseSession(long controlSessionId)
         {
             closeSessionRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -163,7 +163,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool StartRecording(string channel, int streamId, SourceLocation sourceLocation, long correlationId, long controlSessionId)
+        public bool StartRecording(string channel, int streamId, SourceLocation sourceLocation, long correlationId, long controlSessionId)
         {
             startRecordingRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -184,7 +184,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool StopRecording(string channel, int streamId, long correlationId, long controlSessionId)
+        public bool StopRecording(string channel, int streamId, long correlationId, long controlSessionId)
         {
             stopRecordingRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -225,7 +225,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool Replay(long recordingId, long position, long length, string replayChannel, int replayStreamId, long correlationId, long controlSessionId)
+        public bool Replay(long recordingId, long position, long length, string replayChannel, int replayStreamId, long correlationId, long controlSessionId)
         {
             replayRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -247,7 +247,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool StopReplay(long replaySessionId, long correlationId, long controlSessionId)
+        public bool StopReplay(long replaySessionId, long correlationId, long controlSessionId)
         {
             stopReplayRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -266,7 +266,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool ListRecordings(long fromRecordingId, int recordCount, long correlationId, long controlSessionId)
+        public bool ListRecordings(long fromRecordingId, int recordCount, long correlationId, long controlSessionId)
         {
             listRecordingsRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -288,7 +288,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool ListRecordingsForUri(long fromRecordingId, int recordCount, string channel, int streamId, long correlationId, long controlSessionId)
+        public bool ListRecordingsForUri(long fromRecordingId, int recordCount, string channel, int streamId, long correlationId, long controlSessionId)
         {
             listRecordingsForUriRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -309,7 +309,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool ListRecording(long recordingId, long correlationId, long controlSessionId)
+        public bool ListRecording(long recordingId, long correlationId, long controlSessionId)
         {
             listRecordingRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
@@ -330,7 +330,7 @@ namespace Adaptive.Archiver
         /// <param name="correlationId">    for this request. </param>
         /// <param name="controlSessionId"> for this request. </param>
         /// <returns> true if successfully offered otherwise false. </returns>
-        public virtual bool ExtendRecording(string channel, int streamId, SourceLocation sourceLocation, long recordingId, long correlationId, long controlSessionId)
+        public bool ExtendRecording(string channel, int streamId, SourceLocation sourceLocation, long recordingId, long correlationId, long controlSessionId)
         {
             extendRecordingRequestEncoder
                 .WrapAndApplyHeader(buffer, 0, messageHeaderEncoder)

--- a/src/Adaptive.Archiver/ArchiveProxy.cs
+++ b/src/Adaptive.Archiver/ArchiveProxy.cs
@@ -46,8 +46,8 @@ namespace Adaptive.Archiver
         /// Create a proxy with a <seealso cref="Publication"/> for sending control message requests.
         /// <para>
         /// This provides a default <seealso cref="IIdleStrategy"/> of a <seealso cref="YieldingIdleStrategy"/> when offers are back pressured
-        /// with a defaults of <seealso cref="AeronArchive.Configuration#MESSAGE_TIMEOUT_DEFAULT_NS"/> and
-        /// <seealso cref="#DEFAULT_RETRY_ATTEMPTS"/>.
+        /// with a defaults of <seealso cref="AeronArchive.Configuration.MESSAGE_TIMEOUT_DEFAULT_NS"/> and
+        /// <seealso cref="DEFAULT_RETRY_ATTEMPTS"/>.
         /// 
         /// </para>
         /// </summary>
@@ -197,7 +197,7 @@ namespace Adaptive.Archiver
         }
 
         /// <summary>
-        /// Stop an active recording by the <seealso cref="Subscription#registrationId()"/> it was registered with.
+        /// Stop an active recording by the <seealso cref="Subscription.RegistrationId"/> it was registered with.
         /// </summary>
         /// <param name="subscriptionId">   that identifies the subscription in the archive doing the recording. </param>
         /// <param name="correlationId">    for this request. </param>
@@ -219,7 +219,7 @@ namespace Adaptive.Archiver
         /// </summary>
         /// <param name="recordingId">      to be replayed. </param>
         /// <param name="position">         from which the replay should be started. </param>
-        /// <param name="length">           of the stream to be replayed. Use <seealso cref="Long#MAX_VALUE"/> to follow a live stream. </param>
+        /// <param name="length">           of the stream to be replayed. Use <seealso cref="long.MaxValue"/> to follow a live stream. </param>
         /// <param name="replayChannel">    to which the replay should be sent. </param>
         /// <param name="replayStreamId">   to which the replay should be sent. </param>
         /// <param name="correlationId">    for this request. </param>

--- a/src/Adaptive.Archiver/ControlResponseAdaptor.cs
+++ b/src/Adaptive.Archiver/ControlResponseAdaptor.cs
@@ -46,7 +46,7 @@ namespace Adaptive.Archiver
         }
 
         /// <summary>
-        /// Poll for recording events and dispatch them to the <seealso cref="RecordingEventsListener"/> for this instance.
+        /// Poll for recording events and dispatch them to the <seealso cref="IRecordingEventsListener"/> for this instance.
         /// </summary>
         /// <returns> the number of fragments read during the operation. Zero if no events are available. </returns>
         public int Poll()

--- a/src/Adaptive.Archiver/ControlResponseAdaptor.cs
+++ b/src/Adaptive.Archiver/ControlResponseAdaptor.cs
@@ -49,7 +49,7 @@ namespace Adaptive.Archiver
         /// Poll for recording events and dispatch them to the <seealso cref="RecordingEventsListener"/> for this instance.
         /// </summary>
         /// <returns> the number of fragments read during the operation. Zero if no events are available. </returns>
-        public virtual int Poll()
+        public int Poll()
         {
             return subscription.Poll(fragmentAssembler, fragmentLimit);
         }
@@ -64,7 +64,7 @@ namespace Adaptive.Archiver
             consumer.OnRecordingDescriptor(decoder.ControlSessionId(), decoder.CorrelationId(), decoder.RecordingId(), decoder.StartTimestamp(), decoder.StopTimestamp(), decoder.StartPosition(), decoder.StopPosition(), decoder.InitialTermId(), decoder.SegmentFileLength(), decoder.TermBufferLength(), decoder.MtuLength(), decoder.SessionId(), decoder.StreamId(), decoder.StrippedChannel(), decoder.OriginalChannel(), decoder.SourceIdentity());
         }
 
-        public virtual void OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
+        public void OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
         {
             messageHeaderDecoder.Wrap(buffer, offset);
 

--- a/src/Adaptive.Archiver/ControlResponsePoller.cs
+++ b/src/Adaptive.Archiver/ControlResponsePoller.cs
@@ -51,7 +51,7 @@ namespace Adaptive.Archiver
         /// Get the <seealso cref="Subscription"/> used for polling responses.
         /// </summary>
         /// <returns> the <seealso cref="Subscription"/> used for polling responses. </returns>
-        public virtual Subscription Subscription()
+        public Subscription Subscription()
         {
             return subscription;
         }
@@ -60,7 +60,7 @@ namespace Adaptive.Archiver
         /// Poll for recording events.
         /// </summary>
         /// <returns> the number of fragments read during the operation. Zero if no events are available. </returns>
-        public virtual int Poll()
+        public int Poll()
         {
             controlSessionId = -1;
             correlationId = -1;
@@ -75,7 +75,7 @@ namespace Adaptive.Archiver
         /// Control session id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
         /// <returns> control session id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if unrecognised template. </returns>
-        public virtual long ControlSessionId()
+        public long ControlSessionId()
         {
             return controlSessionId;
         }
@@ -84,7 +84,7 @@ namespace Adaptive.Archiver
         /// Correlation id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
         /// <returns> correlation id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if unrecognised template. </returns>
-        public virtual long CorrelationId()
+        public long CorrelationId()
         {
             return correlationId;
         }
@@ -93,7 +93,7 @@ namespace Adaptive.Archiver
         /// Get the relevant id returned with the response, e.g. replay session id.
         /// </summary>
         /// <returns> the relevant id returned with the response. </returns>
-        public virtual long RelevantId()
+        public long RelevantId()
         {
             return relevantId;
         }
@@ -102,7 +102,7 @@ namespace Adaptive.Archiver
         /// Has the last polling action received a complete message?
         /// </summary>
         /// <returns> true if the last polling action received a complete message? </returns>
-        public virtual bool IsPollComplete()
+        public bool IsPollComplete()
         {
             return pollComplete;
         }
@@ -111,7 +111,7 @@ namespace Adaptive.Archiver
         /// Get the template id of the last received message.
         /// </summary>
         /// <returns> the template id of the last received message. </returns>
-        public virtual int TemplateId()
+        public int TemplateId()
         {
             return templateId;
         }
@@ -120,7 +120,7 @@ namespace Adaptive.Archiver
         /// Get the response code of the last response.
         /// </summary>
         /// <returns> the response code of the last response. </returns>
-        public virtual ControlResponseCode Code()
+        public ControlResponseCode Code()
         {
             return code;
         }
@@ -129,12 +129,12 @@ namespace Adaptive.Archiver
         /// Get the error message of the last response.
         /// </summary>
         /// <returns> the error message of the last response. </returns>
-        public virtual string ErrorMessage()
+        public string ErrorMessage()
         {
             return errorMessage;
         }
 
-        public virtual ControlledFragmentHandlerAction OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
+        public ControlledFragmentHandlerAction OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
         {
             messageHeaderDecoder.Wrap(buffer, offset);
 

--- a/src/Adaptive.Archiver/ControlResponsePoller.cs
+++ b/src/Adaptive.Archiver/ControlResponsePoller.cs
@@ -72,18 +72,18 @@ namespace Adaptive.Archiver
         }
 
         /// <summary>
-        /// Control session id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if poll returned nothing.
+        /// Control session id of the last polled message or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
-        /// <returns> control session id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if unrecognised template. </returns>
+        /// <returns> control session id of the last polled message or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if unrecognised template. </returns>
         public long ControlSessionId()
         {
             return controlSessionId;
         }
 
         /// <summary>
-        /// Correlation id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if poll returned nothing.
+        /// Correlation id of the last polled message or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
-        /// <returns> correlation id of the last polled message or <see cref="Aeron.NULL_VALUE"/> if unrecognised template. </returns>
+        /// <returns> correlation id of the last polled message or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if unrecognised template. </returns>
         public long CorrelationId()
         {
             return correlationId;

--- a/src/Adaptive.Archiver/RecordingDescriptorPoller.cs
+++ b/src/Adaptive.Archiver/RecordingDescriptorPoller.cs
@@ -54,7 +54,7 @@ namespace Adaptive.Archiver
         /// Get the <seealso cref="Subscription"/> used for polling responses.
         /// </summary>
         /// <returns> the <seealso cref="Subscription"/> used for polling responses. </returns>
-        public virtual Subscription Subscription()
+        public Subscription Subscription()
         {
             return subscription;
         }
@@ -63,7 +63,7 @@ namespace Adaptive.Archiver
         /// Poll for recording events.
         /// </summary>
         /// <returns> the number of fragments read during the operation. Zero if no events are available. </returns>
-        public virtual int Poll()
+        public int Poll()
         {
             isDispatchComplete = false;
 
@@ -74,7 +74,7 @@ namespace Adaptive.Archiver
         /// Control session id for filtering responses.
         /// </summary>
         /// <returns> control session id for filtering responses. </returns>
-        public virtual long ControlSessionId()
+        public long ControlSessionId()
         {
             return controlSessionId;
         }
@@ -83,7 +83,7 @@ namespace Adaptive.Archiver
         /// Is the dispatch of descriptors complete?
         /// </summary>
         /// <returns> true if the dispatch of descriptors complete? </returns>
-        public virtual bool IsDispatchComplete()
+        public bool IsDispatchComplete()
         {
             return isDispatchComplete;
         }
@@ -92,7 +92,7 @@ namespace Adaptive.Archiver
         /// Get the number of remaining records are expected.
         /// </summary>
         /// <returns> the number of remaining records are expected. </returns>
-        public virtual int RemainingRecordCount()
+        public int RemainingRecordCount()
         {
             return remainingRecordCount;
         }
@@ -103,7 +103,7 @@ namespace Adaptive.Archiver
         /// <param name="expectedCorrelationId"> for the response. </param>
         /// <param name="recordCount">           of descriptors to expect. </param>
         /// <param name="consumer">              to which the recording descriptors are to be dispatched. </param>
-        public virtual void Reset(long expectedCorrelationId, int recordCount, IRecordingDescriptorConsumer consumer)
+        public void Reset(long expectedCorrelationId, int recordCount, IRecordingDescriptorConsumer consumer)
         {
             this.expectedCorrelationId = expectedCorrelationId;
             this.consumer = consumer;
@@ -111,7 +111,7 @@ namespace Adaptive.Archiver
             isDispatchComplete = false;
         }
 
-        public virtual ControlledFragmentHandlerAction OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
+        public ControlledFragmentHandlerAction OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
         {
             messageHeaderDecoder.Wrap(buffer, offset);
 

--- a/src/Adaptive.Archiver/RecordingEventsAdapter.cs
+++ b/src/Adaptive.Archiver/RecordingEventsAdapter.cs
@@ -36,12 +36,12 @@ namespace Adaptive.Archiver
         /// Poll for recording events and dispatch them to the <seealso cref="IRecordingEventsListener"/> for this instance.
         /// </summary>
         /// <returns> the number of fragments read during the operation. Zero if no events are available. </returns>
-        public virtual int Poll()
+        public int Poll()
         {
             return _subscription.Poll(this, _fragmentLimit);
         }
 
-        public virtual void OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
+        public void OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
         {
             _messageHeaderDecoder.Wrap(buffer, offset);
 

--- a/src/Adaptive.Archiver/RecordingEventsPoller.cs
+++ b/src/Adaptive.Archiver/RecordingEventsPoller.cs
@@ -38,7 +38,7 @@ namespace Adaptive.Archiver
         /// Poll for recording events.
         /// </summary>
         /// <returns> the number of fragments read during the operation. Zero if no events are available. </returns>
-        public virtual int Poll()
+        public int Poll()
         {
             templateId = Aeron.Aeron.NULL_VALUE;
             pollComplete = false;
@@ -50,7 +50,7 @@ namespace Adaptive.Archiver
         /// Has the last polling action received a complete message?
         /// </summary>
         /// <returns> true of the last polling action received a complete message? </returns>
-        public virtual bool IsPollComplete()
+        public bool IsPollComplete()
         {
             return pollComplete;
         }
@@ -59,7 +59,7 @@ namespace Adaptive.Archiver
         /// Get the template id of the last received message.
         /// </summary>
         /// <returns> the template id of the last received message. </returns>
-        public virtual int TemplateId()
+        public int TemplateId()
         {
             return templateId;
         }
@@ -68,7 +68,7 @@ namespace Adaptive.Archiver
         /// Get the recording id of the last received event.
         /// </summary>
         /// <returns> the recording id of the last received event. </returns>
-        public virtual long RecordingId()
+        public long RecordingId()
         {
             return recordingId;
         }
@@ -77,7 +77,7 @@ namespace Adaptive.Archiver
         /// Get the position the recording started at.
         /// </summary>
         /// <returns> the position the recording started at. </returns>
-        public virtual long RecordingStartPosition()
+        public long RecordingStartPosition()
         {
             return recordingStartPosition;
         }
@@ -86,7 +86,7 @@ namespace Adaptive.Archiver
         /// Get the current recording position.
         /// </summary>
         /// <returns> the current recording position. </returns>
-        public virtual long RecordingPosition()
+        public long RecordingPosition()
         {
             return recordingPosition;
         }
@@ -95,12 +95,12 @@ namespace Adaptive.Archiver
         /// Get the position the recording stopped at.
         /// </summary>
         /// <returns> the position the recording stopped at. </returns>
-        public virtual long RecordingStopPosition()
+        public long RecordingStopPosition()
         {
             return recordingStopPosition;
         }
 
-        public virtual void OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
+        public void OnFragment(IDirectBuffer buffer, int offset, int length, Header header)
         {
             messageHeaderDecoder.Wrap(buffer, offset);
 

--- a/src/Adaptive.Cluster/Client/AeronCluster.cs
+++ b/src/Adaptive.Cluster/Client/AeronCluster.cs
@@ -1200,7 +1200,7 @@ namespace Adaptive.Cluster.Client
             /// </summary>
             /// <param name="errorHandler"> Method to handle objects of type Throwable. </param>
             /// <returns> this for fluent API. </returns>
-            public virtual Context ErrorHandler(ErrorHandler errorHandler)
+            public Context ErrorHandler(ErrorHandler errorHandler)
             {
                 _errorHandler = errorHandler;
                 return this;

--- a/src/Adaptive.Cluster/Client/AeronCluster.cs
+++ b/src/Adaptive.Cluster/Client/AeronCluster.cs
@@ -143,7 +143,7 @@ namespace Adaptive.Cluster.Client
         }
 
         /// <summary>
-        /// Connect to the cluster providing <seealso cref="Aeron.Context"/> for configuration.
+        /// Connect to the cluster providing <seealso cref="Adaptive.Aeron.Aeron.Context"/> for configuration.
         /// </summary>
         /// <param name="ctx"> for configuration. </param>
         /// <returns> allocated cluster client if the connection is successful. </returns>
@@ -171,13 +171,15 @@ namespace Adaptive.Cluster.Client
 
                 _clusterSessionId = ConnectToCluster();
 
-                UnsafeBuffer headerBuffer = new UnsafeBuffer(new byte[IngressSessionDecorator.INGRESS_MESSAGE_HEADER_LENGTH]);
+                UnsafeBuffer headerBuffer =
+                    new UnsafeBuffer(new byte[IngressSessionDecorator.INGRESS_MESSAGE_HEADER_LENGTH]);
                 _ingressMessageHeaderEncoder
                     .WrapAndApplyHeader(headerBuffer, 0, _messageHeaderEncoder)
                     .ClusterSessionId(_clusterSessionId)
                     .LeadershipTermId(_leadershipTermId);
 
-                _vectors[0] = new DirectBufferVector(headerBuffer, 0, IngressSessionDecorator.INGRESS_MESSAGE_HEADER_LENGTH);
+                _vectors[0] = new DirectBufferVector(headerBuffer, 0,
+                    IngressSessionDecorator.INGRESS_MESSAGE_HEADER_LENGTH);
                 _vectors[1] = _messageVector;
 
                 _poller = new Poller(ctx.EgressListener(), _clusterSessionId, this);
@@ -238,7 +240,7 @@ namespace Adaptive.Cluster.Client
         /// </summary>
         /// <returns> leadership term identity for the cluster. </returns>
         public long LeadershipTermId => _leadershipTermId;
-        
+
 
         /// <summary>
         /// Get the current leader member id for the cluster.
@@ -277,7 +279,7 @@ namespace Adaptive.Cluster.Client
         /// <param name="buffer">        containing message. </param>
         /// <param name="offset">        offset in the buffer at which the encoded message begins. </param>
         /// <param name="length">        in bytes of the encoded message. </param>
-        /// <returns> the same as <seealso cref="Publication.Offer(IDirectBuffer, int, int)"/>. </returns>
+        /// <returns> the same as <seealso cref="Publication.Offer(IDirectBuffer, int, int, ReservedValueSupplier)"/>. </returns>
         public long Offer(IDirectBuffer buffer, int offset, int length)
         {
             _messageVector.Reset(buffer, offset, length);
@@ -325,9 +327,9 @@ namespace Adaptive.Cluster.Client
 
         /// <summary>
         /// Poll the <seealso cref="EgressSubscription()"/> for session messages which are dispatched to
-        /// <seealso cref="Context.EgressListener"/>.
+        /// <seealso cref="Context.EgressListener()"/>.
         /// <para>
-        /// <b>Note:</b> if <seealso cref="Context.EgressListener"/> is not set then a <seealso cref="ConfigurationException"/> could result.
+        /// <b>Note:</b> if <seealso cref="Context.EgressListener()"/> is not set then a <seealso cref="ConfigurationException"/> could result.
         ///    
         /// </para>
         /// </summary>
@@ -345,7 +347,8 @@ namespace Adaptive.Cluster.Client
         /// <param name="leadershipTermId"> that identifies the term for which the new leader has been elected.</param>
         /// <param name="leaderMemberId">   which has become the new leader. </param>
         /// <param name="memberEndpoints">  comma separated list of cluster members endpoints to connect to with the leader first. </param>
-        public void OnNewLeader(long clusterSessionId, long leadershipTermId, int leaderMemberId, string memberEndpoints)
+        public void OnNewLeader(long clusterSessionId, long leadershipTermId, int leaderMemberId,
+            string memberEndpoints)
         {
             if (clusterSessionId != _clusterSessionId)
             {
@@ -501,7 +504,8 @@ namespace Adaptive.Cluster.Client
                 AwaitConnectedPublication(deadlineNs);
                 byte[] encodedCredentials = _ctx.CredentialsSupplier().EncodedCredentials();
 
-                return OpenSession(deadlineNs, new EgressPoller(_subscription, CONNECT_FRAGMENT_LIMIT), encodedCredentials);
+                return OpenSession(deadlineNs, new EgressPoller(_subscription, CONNECT_FRAGMENT_LIMIT),
+                    encodedCredentials);
             }
         }
 
@@ -774,7 +778,7 @@ namespace Adaptive.Cluster.Client
             }
 
             /// <summary>
-            /// The value <seealso cref="#NGRESS_CHANNEL_DEFAULT"/> or system property
+            /// The value <seealso cref="INGRESS_CHANNEL_DEFAULT"/> or system property
             /// <seealso cref="INGRESS_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
             /// <returns> <seealso cref="INGRESS_CHANNEL_DEFAULT"/> or system property
@@ -1049,7 +1053,7 @@ namespace Adaptive.Cluster.Client
             /// Get the stream id for the egress channel.
             /// </summary>
             /// <returns> the stream id for the egress channel. </returns>
-            /// <seealso cref="Configuration.EGRESS_STREAM_ID_PROP_NAME"/></seealso>
+            /// <seealso cref="Configuration.EGRESS_STREAM_ID_PROP_NAME"/>
             public int EgressStreamId()
             {
                 return _egressStreamId;

--- a/src/Adaptive.Cluster/Client/EgressPoller.cs
+++ b/src/Adaptive.Cluster/Client/EgressPoller.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Adaptive.Aeron;
+﻿using Adaptive.Aeron;
 using Adaptive.Aeron.LogBuffer;
 using Adaptive.Agrona;
 using Adaptive.Cluster.Codecs;
@@ -53,36 +52,36 @@ namespace Adaptive.Cluster.Client
         }
 
         /// <summary>
-        /// Cluster session id of the last polled event or <see cref="Aeron.NULL_VALUE"/> if poll returned nothing.
+        /// Cluster session id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
-        /// <returns> cluster session id of the last polled event or <see cref="Aeron.NULL_VALUE"/> if not returned. </returns>
+        /// <returns> cluster session id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if not returned. </returns>
         public long ClusterSessionId()
         {
             return clusterSessionId;
         }
 
         /// <summary>
-        /// Correlation id of the last polled event or <see cref="Aeron.NULL_VALUE"/> if poll returned nothing.
+        /// Correlation id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
-        /// <returns> correlation id of the last polled event or <see cref="Aeron.NULL_VALUE"/> if not returned. </returns>
+        /// <returns> correlation id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if not returned. </returns>
         public long CorrelationId()
         {
             return correlationId;
         }
         
         /// <summary>
-        /// Leadership term id of the last polled event or <seealso cref="Aeron.NULL_VALUE"/> if poll returned nothing.
+        /// Leadership term id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
-        /// <returns> leadership term id of the last polled event or <seealso cref="Aeron.NULL_VALUE"/> if not returned. </returns>
+        /// <returns> leadership term id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if not returned. </returns>
         public long LeadershipTermId()
         {
             return leadershipTermId;
         }
         
         /// <summary>
-        /// Leader cluster member id of the last polled event or <seealso cref="Aeron#NULL_VALUE"/> if poll returned nothing.
+        /// Leader cluster member id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing.
         /// </summary>
-        /// <returns> leader cluster member id of the last polled event or <seealso cref="Aeron#NULL_VALUE"/> if poll returned nothing. </returns>
+        /// <returns> leader cluster member id of the last polled event or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if poll returned nothing. </returns>
         public int LeaderMemberId()
         {
             return leaderMemberId;

--- a/src/Adaptive.Cluster/Client/IngressSessionDecorator.cs
+++ b/src/Adaptive.Cluster/Client/IngressSessionDecorator.cs
@@ -25,7 +25,7 @@ namespace Adaptive.Cluster.Client
         private readonly IngressMessageHeaderEncoder ingressMessageHeaderEncoder = new IngressMessageHeaderEncoder();
 
         /// <summary>
-        /// Construct a new ingress session header wrapper that defaults all fields to the <see cref="Aeron.NULL_VALUE"/>
+        /// Construct a new ingress session header wrapper that defaults all fields to the <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/>
         /// </summary>
         public IngressSessionDecorator() : this(Aeron.Aeron.NULL_VALUE, Aeron.Aeron.NULL_VALUE)
         {
@@ -74,7 +74,7 @@ namespace Adaptive.Cluster.Client
         /// <summary>
         /// Non-blocking publish of a partial buffer containing a message plus session header to a cluster.
         /// <para>
-        /// This version of the method will set the timestamp value in the header to <see cref="Aeron.NULL_VALUE"/>.
+        /// This version of the method will set the timestamp value in the header to <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/>.
         /// 
         /// </para>
         /// </summary>
@@ -82,7 +82,7 @@ namespace Adaptive.Cluster.Client
         /// <param name="buffer">        containing message. </param>
         /// <param name="offset">        offset in the buffer at which the encoded message begins. </param>
         /// <param name="length">        in bytes of the encoded message. </param>
-        /// <returns> the same as <seealso cref="Publication.Offer(UnsafeBuffer, int, int)"/>. </returns>
+        /// <returns> the same as <seealso cref="Publication.Offer(IDirectBuffer, int, int, ReservedValueSupplier)"/>. </returns>
         public long Offer(Publication publication, IDirectBuffer buffer, int offset, int length)
         {
             messageVector.Reset(buffer, offset, length);

--- a/src/Adaptive.Cluster/Service/BoundedLogAdapter.cs
+++ b/src/Adaptive.Cluster/Service/BoundedLogAdapter.cs
@@ -34,7 +34,7 @@ namespace Adaptive.Cluster.Service
 
         internal BoundedLogAdapter(Image image, ReadableCounter upperBound, ClusteredServiceAgent agent)
         {
-            fragmentAssembler = new ImageControlledFragmentAssembler(this, INITIAL_BUFFER_LENGTH, true);
+            fragmentAssembler = new ImageControlledFragmentAssembler(this, INITIAL_BUFFER_LENGTH);
             this.image = image;
             this.upperBound = upperBound;
             this.agent = agent;

--- a/src/Adaptive.Cluster/Service/ClientSession.cs
+++ b/src/Adaptive.Cluster/Service/ClientSession.cs
@@ -66,7 +66,7 @@ namespace Adaptive.Cluster.Service
         /// <param name="buffer"> containing message. </param>
         /// <param name="offset"> offset in the buffer at which the encoded message begins. </param>
         /// <param name="length"> in bytes of the encoded message. </param>
-        /// <returns> the same as <seealso cref="Publication.Offer(IDirectBuffer, int, int)"/> when in <seealso cref="ClusterRole.Leader"/>
+        /// <returns> the same as <seealso cref="Publication.Offer(IDirectBuffer, int, int, ReservedValueSupplier)"/> when in <seealso cref="ClusterRole.Leader"/>
         /// otherwise <see cref="MOCKED_OFFER"/>. </returns>
         public long Offer(IDirectBuffer buffer, int offset, int length)
         {

--- a/src/Adaptive.Cluster/Service/ClusterMarkFile.cs
+++ b/src/Adaptive.Cluster/Service/ClusterMarkFile.cs
@@ -130,7 +130,7 @@ namespace Adaptive.Cluster
         /// <summary>
         /// Get the current value of a candidate term id if a vote is placed in an election.
         /// </summary>
-        /// <returns> the current candidate term id within an election after voting or <seealso cref="Aeron#NULL_VALUE"/> if
+        /// <returns> the current candidate term id within an election after voting or <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if
         /// no voting phase of an election is currently active. </returns>
         public long CandidateTermId()
         {

--- a/src/Adaptive.Cluster/Service/ClusteredServiceContainer.cs
+++ b/src/Adaptive.Cluster/Service/ClusteredServiceContainer.cs
@@ -233,37 +233,37 @@ namespace Adaptive.Cluster.Service
             public const bool RESPONDER_SERVICE_DEFAULT = true;
             
             /// <summary>
-            /// The value <seealso cref="#SERVICE_ID_DEFAULT"/> or system property <seealso cref="#SERVICE_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="SERVICE_ID_DEFAULT"/> or system property <seealso cref="SERVICE_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#SERVICE_ID_DEFAULT"/> or system property <seealso cref="#SERVICE_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="SERVICE_ID_DEFAULT"/> or system property <seealso cref="SERVICE_ID_PROP_NAME"/> if set. </returns>
             public static int ServiceId()
             {
                 return Config.GetInteger(SERVICE_ID_PROP_NAME, SERVICE_ID_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#SERVICE_NAME_DEFAULT"/> or system property <seealso cref="#SERVICE_NAME_PROP_NAME"/> if set.
+            /// The value <seealso cref="SERVICE_NAME_DEFAULT"/> or system property <seealso cref="SERVICE_NAME_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#SERVICE_NAME_DEFAULT"/> or system property <seealso cref="#SERVICE_NAME_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="SERVICE_NAME_DEFAULT"/> or system property <seealso cref="SERVICE_NAME_PROP_NAME"/> if set. </returns>
             public static string ServiceName()
             {
                 return Config.GetProperty(SERVICE_NAME_PROP_NAME, SERVICE_NAME_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#REPLAY_CHANNEL_DEFAULT"/> or system property <seealso cref="#REPLAY_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="REPLAY_CHANNEL_DEFAULT"/> or system property <seealso cref="REPLAY_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#REPLAY_CHANNEL_DEFAULT"/> or system property <seealso cref="#REPLAY_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="REPLAY_CHANNEL_DEFAULT"/> or system property <seealso cref="REPLAY_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string ReplayChannel()
             {
                 return Config.GetProperty(REPLAY_CHANNEL_PROP_NAME, REPLAY_CHANNEL_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#REPLAY_STREAM_ID_DEFAULT"/> or system property <seealso cref="#REPLAY_STREAM_ID_PROP_NAME"/>
+            /// The value <seealso cref="REPLAY_STREAM_ID_DEFAULT"/> or system property <seealso cref="REPLAY_STREAM_ID_PROP_NAME"/>
             /// if set.
             /// </summary>
-            /// <returns> <seealso cref="#REPLAY_STREAM_ID_DEFAULT"/> or system property <seealso cref="#REPLAY_STREAM_ID_PROP_NAME"/>
+            /// <returns> <seealso cref="REPLAY_STREAM_ID_DEFAULT"/> or system property <seealso cref="REPLAY_STREAM_ID_PROP_NAME"/>
             /// if set. </returns>
             public static int ReplayStreamId()
             {
@@ -271,52 +271,52 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// The value <seealso cref="#SERVICE_CONTROL_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#SERVICE_CONTROL_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="SERVICE_CONTROL_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="SERVICE_CONTROL_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#SERVICE_CONTROL_CHANNEL_DEFAULT"/> or system property
-            /// <seealso cref="#SERVICE_CONTROL_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="SERVICE_CONTROL_CHANNEL_DEFAULT"/> or system property
+            /// <seealso cref="SERVICE_CONTROL_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string ServiceControlChannel()
             {
                 return Config.GetProperty(SERVICE_CONTROL_CHANNEL_PROP_NAME, SERVICE_CONTROL_CHANNEL_DEFAULT);
             }
             
             /// <summary>
-            /// The value <seealso cref="#CONSENSUS_MODULE_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#CONSENSUS_MODULE_STREAM_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="CONSENSUS_MODULE_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="CONSENSUS_MODULE_STREAM_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#CONSENSUS_MODULE_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#CONSENSUS_MODULE_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="CONSENSUS_MODULE_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="CONSENSUS_MODULE_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int ConsensusModuleStreamId()
             {
                 return Config.GetInteger(CONSENSUS_MODULE_STREAM_ID_PROP_NAME, CONSENSUS_MODULE_STREAM_ID_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#SERVICE_CONTROL_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#SERVICE_STREAM_ID_PROP_NAME"/> if set.
+            /// The value <seealso cref="SERVICE_CONTROL_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="SERVICE_STREAM_ID_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#SERVICE_CONTROL_STREAM_ID_DEFAULT"/> or system property
-            /// <seealso cref="#SERVICE_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="SERVICE_CONTROL_STREAM_ID_DEFAULT"/> or system property
+            /// <seealso cref="SERVICE_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int ServiceStreamId()
             {
                 return Config.GetInteger(SERVICE_STREAM_ID_PROP_NAME, SERVICE_CONTROL_STREAM_ID_DEFAULT);
             }
             
             /// <summary>
-            /// The value <seealso cref="#SNAPSHOT_CHANNEL_DEFAULT"/> or system property <seealso cref="#SNAPSHOT_CHANNEL_PROP_NAME"/> if set.
+            /// The value <seealso cref="SNAPSHOT_CHANNEL_DEFAULT"/> or system property <seealso cref="SNAPSHOT_CHANNEL_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#SNAPSHOT_CHANNEL_DEFAULT"/> or system property <seealso cref="#SNAPSHOT_CHANNEL_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="SNAPSHOT_CHANNEL_DEFAULT"/> or system property <seealso cref="SNAPSHOT_CHANNEL_PROP_NAME"/> if set. </returns>
             public static string SnapshotChannel()
             {
                 return Config.GetProperty(SNAPSHOT_CHANNEL_PROP_NAME, SNAPSHOT_CHANNEL_DEFAULT);
             }
 
             /// <summary>
-            /// The value <seealso cref="#SNAPSHOT_STREAM_ID_DEFAULT"/> or system property <seealso cref="#SNAPSHOT_STREAM_ID_PROP_NAME"/>
+            /// The value <seealso cref="SNAPSHOT_STREAM_ID_DEFAULT"/> or system property <seealso cref="SNAPSHOT_STREAM_ID_PROP_NAME"/>
             /// if set.
             /// </summary>
-            /// <returns> <seealso cref="#SNAPSHOT_STREAM_ID_DEFAULT"/> or system property <seealso cref="#SNAPSHOT_STREAM_ID_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="SNAPSHOT_STREAM_ID_DEFAULT"/> or system property <seealso cref="SNAPSHOT_STREAM_ID_PROP_NAME"/> if set. </returns>
             public static int SnapshotStreamId()
             {
                 return Config.GetInteger(SNAPSHOT_STREAM_ID_PROP_NAME, SNAPSHOT_STREAM_ID_DEFAULT);
@@ -326,9 +326,9 @@ namespace Adaptive.Cluster.Service
             public const string CLUSTER_IDLE_STRATEGY_PROP_NAME = "aeron.cluster.idle.strategy";
 
             /// <summary>
-            /// Create a supplier of <seealso cref="IdleStrategy"/>s that will use the system property.
+            /// Create a supplier of <seealso cref="IIdleStrategy"/>s that will use the system property.
             /// </summary>
-            /// <param name="controllableStatus"> if a <seealso cref="org.agrona.concurrent.ControllableIdleStrategy"/> is required. </param>
+            /// <param name="controllableStatus"> if a <seealso cref="ControllableIdleStrategy"/> is required. </param>
             /// <returns> the new idle strategy </returns>
             public static Func<IIdleStrategy> IdleStrategySupplier(StatusIndicator controllableStatus)
             {
@@ -340,9 +340,9 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// The value <seealso cref="#CLUSTER_DIR_DEFAULT"/> or system property <seealso cref="#CLUSTER_DIR_PROP_NAME"/> if set.
+            /// The value <seealso cref="CLUSTER_DIR_DEFAULT"/> or system property <seealso cref="CLUSTER_DIR_PROP_NAME"/> if set.
             /// </summary>
-            /// <returns> <seealso cref="#CLUSTER_DIR_DEFAULT"/> or system property <seealso cref="#CLUSTER_DIR_PROP_NAME"/> if set. </returns>
+            /// <returns> <seealso cref="CLUSTER_DIR_DEFAULT"/> or system property <seealso cref="CLUSTER_DIR_PROP_NAME"/> if set. </returns>
             public static string ClusterDirName()
             {
                 return Config.GetProperty(CLUSTER_DIR_PROP_NAME, CLUSTER_DIR_DEFAULT);
@@ -535,7 +535,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="serviceId"> for this clustered service. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SERVICE_ID_PROP_NAME"></seealso>
             public Context ServiceId(int serviceId)
             {
                 this.serviceId = serviceId;
@@ -546,7 +546,7 @@ namespace Adaptive.Cluster.Service
             /// Get the id for this clustered service. Services should be numbered from 0 and be contiguous.
             /// </summary>
             /// <returns> the id for this clustered service. </returns>
-            /// <seealso cref= ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SERVICE_ID_PROP_NAME"></seealso>
             public int ServiceId()
             {
                 return serviceId;
@@ -580,7 +580,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="channel"> parameter for the cluster log replay channel. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= ClusteredServiceContainer.Configuration#REPLAY_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.REPLAY_CHANNEL_PROP_NAME"></seealso>
             public Context ReplayChannel(string channel)
             {
                 replayChannel = channel;
@@ -591,7 +591,7 @@ namespace Adaptive.Cluster.Service
             /// Get the channel parameter for the cluster log and snapshot replay channel.
             /// </summary>
             /// <returns> the channel parameter for the cluster replay channel. </returns>
-            /// <seealso cref= ClusteredServiceContainer.Configuration#REPLAY_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.REPLAY_CHANNEL_PROP_NAME"></seealso>
             public string ReplayChannel()
             {
                 return replayChannel;
@@ -602,7 +602,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="streamId"> for the cluster log replay channel. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= ClusteredServiceContainer.Configuration#REPLAY_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.REPLAY_STREAM_ID_PROP_NAME"></seealso>
             public Context ReplayStreamId(int streamId)
             {
                 replayStreamId = streamId;
@@ -613,7 +613,7 @@ namespace Adaptive.Cluster.Service
             /// Get the stream id for the cluster log and snapshot replay channel.
             /// </summary>
             /// <returns> the stream id for the cluster log replay channel. </returns>
-            /// <seealso cref= ClusteredServiceContainer.Configuration#REPLAY_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.REPLAY_STREAM_ID_PROP_NAME"></seealso>
             public int ReplayStreamId()
             {
                 return replayStreamId;
@@ -624,7 +624,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="channel"> parameter for sending messages to the Consensus Module. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#CONSENSUS_MODULE_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SERVICE_CONTROL_CHANNEL_PROP_NAME"></seealso>
             public Context ServiceControlChannel(string channel)
             {
                 serviceControlChannel = channel;
@@ -635,7 +635,7 @@ namespace Adaptive.Cluster.Service
             /// Get the channel parameter for sending messages to the Consensus Module.
             /// </summary>
             /// <returns> the channel parameter for sending messages to the Consensus Module. </returns>
-            /// <seealso cref= Configuration#CONSENSUS_MODULE_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SERVICE_CONTROL_CHANNEL_PROP_NAME"></seealso>
             public string ServiceControlChannel()
             {
                 return serviceControlChannel;
@@ -646,7 +646,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="streamId"> for communications from the consensus module and to the services. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= Configuration#SERVICE_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SERVICE_STREAM_ID_PROP_NAME"></seealso>
             public Context ServiceStreamId(int streamId)
             {
                 serviceStreamId = streamId;
@@ -657,7 +657,7 @@ namespace Adaptive.Cluster.Service
             /// Get the stream id for communications from the consensus module and to the services.
             /// </summary>
             /// <returns> the stream id for communications from the consensus module and to the services. </returns>
-            /// <seealso cref= Configuration#SERVICE_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SERVICE_STREAM_ID_PROP_NAME"></seealso>
             public int ServiceStreamId()
             {
                 return serviceStreamId;
@@ -668,7 +668,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="streamId"> for communications from the services to the consensus module. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= Configuration#CONSENSUS_MODULE_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONSENSUS_MODULE_STREAM_ID_PROP_NAME"></seealso>
             public Context ConsensusModuleStreamId(int streamId)
             {
                 consensusModuleStreamId = streamId;
@@ -679,7 +679,7 @@ namespace Adaptive.Cluster.Service
             /// Get the stream id for communications from the services to the consensus module.
             /// </summary>
             /// <returns> the stream id for communications from the services to the consensus module. </returns>
-            /// <seealso cref= Configuration#CONSENSUS_MODULE_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CONSENSUS_MODULE_STREAM_ID_PROP_NAME"></seealso>
             public int ConsensusModuleStreamId()
             {
                 return consensusModuleStreamId;
@@ -690,7 +690,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="channel"> parameter for snapshot recordings </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#SNAPSHOT_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SNAPSHOT_CHANNEL_PROP_NAME"></seealso>
             public Context SnapshotChannel(string channel)
             {
                 snapshotChannel = channel;
@@ -701,7 +701,7 @@ namespace Adaptive.Cluster.Service
             /// Get the channel parameter for snapshot recordings.
             /// </summary>
             /// <returns> the channel parameter for snapshot recordings. </returns>
-            /// <seealso cref= Configuration#SNAPSHOT_CHANNEL_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SNAPSHOT_CHANNEL_PROP_NAME"></seealso>
             public string SnapshotChannel()
             {
                 return snapshotChannel;
@@ -712,7 +712,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="streamId"> for snapshot recordings. </param>
             /// <returns> this for a fluent API </returns>
-            /// <seealso cref= Configuration#SNAPSHOT_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SNAPSHOT_STREAM_ID_PROP_NAME"></seealso>
             public Context SnapshotStreamId(int streamId)
             {
                 snapshotStreamId = streamId;
@@ -723,7 +723,7 @@ namespace Adaptive.Cluster.Service
             /// Get the stream id for snapshot recordings.
             /// </summary>
             /// <returns> the stream id for snapshot recordings. </returns>
-            /// <seealso cref= Configuration#SNAPSHOT_STREAM_ID_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.SNAPSHOT_STREAM_ID_PROP_NAME"></seealso>
             public int SnapshotStreamId()
             {
                 return snapshotStreamId;
@@ -792,9 +792,9 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// Set the <seealso cref="EpochClock"/> to be used for tracking wall clock time when interacting with the archive.
+            /// Set the <seealso cref="IEpochClock"/> to be used for tracking wall clock time when interacting with the archive.
             /// </summary>
-            /// <param name="clock"> <seealso cref="EpochClock"/> to be used for tracking wall clock time when interacting with the archive. </param>
+            /// <param name="clock"> <seealso cref="IEpochClock"/> to be used for tracking wall clock time when interacting with the archive. </param>
             /// <returns> this for a fluent API. </returns>
             public Context EpochClock(IEpochClock clock)
             {
@@ -803,9 +803,9 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// Get the <seealso cref="EpochClock"/> to used for tracking wall clock time within the archive.
+            /// Get the <seealso cref="IEpochClock"/> to used for tracking wall clock time within the archive.
             /// </summary>
-            /// <returns> the <seealso cref="EpochClock"/> to used for tracking wall clock time within the archive. </returns>
+            /// <returns> the <seealso cref="IEpochClock"/> to used for tracking wall clock time within the archive. </returns>
             public IEpochClock EpochClock()
             {
                 return epochClock;
@@ -863,9 +863,9 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// The <seealso cref="#errorHandler()"/> that will increment <seealso cref="#errorCounter()"/> by default.
+            /// The <seealso cref="ErrorHandler()"/> that will increment <seealso cref="ErrorCounter()"/> by default.
             /// </summary>
-            /// <returns> <seealso cref="#errorHandler()"/> that will increment <seealso cref="#errorCounter()"/> by default. </returns>
+            /// <returns> <seealso cref="ErrorHandler()"/> that will increment <seealso cref="ErrorCounter()"/> by default. </returns>
             public CountedErrorHandler CountedErrorHandler()
             {
                 return countedErrorHandler;
@@ -916,9 +916,9 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// Does this context own the <seealso cref="#aeron()"/> client and this takes responsibility for closing it?
+            /// Does this context own the <seealso cref="Aeron()"/> client and this takes responsibility for closing it?
             /// </summary>
-            /// <param name="ownsAeronClient"> does this context own the <seealso cref="#aeron()"/> client. </param>
+            /// <param name="ownsAeronClient"> does this context own the <seealso cref="Aeron()"/> client. </param>
             /// <returns> this for a fluent API. </returns>
             public Context OwnsAeronClient(bool ownsAeronClient)
             {
@@ -927,9 +927,9 @@ namespace Adaptive.Cluster.Service
             }
 
             /// <summary>
-            /// Does this context own the <seealso cref="#aeron()"/> client and this takes responsibility for closing it?
+            /// Does this context own the <seealso cref="Aeron()"/> client and this takes responsibility for closing it?
             /// </summary>
-            /// <returns> does this context own the <seealso cref="#aeron()"/> client and this takes responsibility for closing it? </returns>
+            /// <returns> does this context own the <seealso cref="Aeron()"/> client and this takes responsibility for closing it? </returns>
             public bool OwnsAeronClient()
             {
                 return ownsAeronClient;
@@ -1002,7 +1002,7 @@ namespace Adaptive.Cluster.Service
             /// </summary>
             /// <param name="clusterDir"> to use. </param>
             /// <returns> this for a fluent API. </returns>
-            /// <seealso cref= Configuration#CLUSTERED_SERVICE_DIR_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CLUSTER_DIR_PROP_NAME"></seealso>
             public Context ClusterDir(DirectoryInfo clusterDir)
             {
                 this.clusterDir = clusterDir;
@@ -1013,7 +1013,7 @@ namespace Adaptive.Cluster.Service
             /// The directory used for for the cluster directory.
             /// </summary>
             /// <returns>  directory for for the cluster directory. </returns>
-            /// <seealso cref= Configuration#CLUSTERED_SERVICE_DIR_PROP_NAME </seealso>
+            /// <seealso cref="Configuration.CLUSTER_DIR_PROP_NAME"></seealso>
             public DirectoryInfo ClusterDir()
             {
                 return clusterDir;
@@ -1041,7 +1041,7 @@ namespace Adaptive.Cluster.Service
 
             /// <summary>
             /// Set the <seealso cref="Action"/> that is called when processing a
-            /// <seealso cref="ServiceAction.SHUTDOWN"/> or <seealso cref="ServiceAction.ABORT"/>
+            /// <seealso cref="ClusterAction.SHUTDOWN"/> or <seealso cref="ClusterAction.ABORT"/>
             /// </summary>
             /// <param name="terminationHook"> that can be used to terminate a service container. </param>
             /// <returns> this for a fluent API. </returns>
@@ -1055,7 +1055,7 @@ namespace Adaptive.Cluster.Service
             /// Get the <seealso cref="Action"/> that is called when processing a
             /// <seealso cref="ClusterAction.SHUTDOWN"/> or <seealso cref="ClusterAction.ABORT"/>
             /// <para>
-            /// The default action is to call signal on the <seealso cref="#shutdownSignalBarrier()"/>.
+            /// The default action is to call signal on the <seealso cref="ShutdownSignalBarrier()"/>.
             /// 
             /// </para>
             /// </summary>

--- a/src/Adaptive.Cluster/Service/IClusteredService.cs
+++ b/src/Adaptive.Cluster/Service/IClusteredService.cs
@@ -62,7 +62,7 @@ namespace Adaptive.Cluster.Service
         /// The service should take a snapshot and store its state to the provided archive <seealso cref="Publication"/>.
         /// <para>
         /// <b>Note:</b> As this is a potentially long running operation the implementation should occasional call
-        /// <seealso cref="Thread#isInterrupted()"/> and if true then throw an <seealso cref="ThreadInterruptedException"/> or
+        /// check for thread interruption <see cref="Thread.Sleep(int)"/> and throw an <seealso cref="ThreadInterruptedException"/> or
         /// <seealso cref="AgentTerminationException"/>.
         /// 
         /// </para>

--- a/src/Adaptive.Cluster/Service/RecoveryState.cs
+++ b/src/Adaptive.Cluster/Service/RecoveryState.cs
@@ -133,11 +133,11 @@ namespace Adaptive.Cluster.Service
         }
 
         /// <summary>
-        /// Get the leadership term id for the snapshot state. <see cref="Aeron.NULL_VALUE"/> if no snapshot for recovery.
+        /// Get the leadership term id for the snapshot state. <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if no snapshot for recovery.
         /// </summary>
         /// <param name="counters">  to search within. </param>
         /// <param name="counterId"> for the active consensus position. </param>
-        /// <returns> the leadership term id if found otherwise <see cref="Aeron.NULL_VALUE"/>. </returns>
+        /// <returns> the leadership term id if found otherwise <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/>. </returns>
         public static long GetLeadershipTermId(CountersReader counters, int counterId)
         {
             IDirectBuffer buffer = counters.MetaDataBuffer;
@@ -156,11 +156,11 @@ namespace Adaptive.Cluster.Service
         }
 
         /// <summary>
-        ///  Get the position at which the snapshot was taken. <seealso cref="Aeron.NULL_VALUE"/> if no snapshot for recovery.
+        ///  Get the position at which the snapshot was taken. <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if no snapshot for recovery.
         /// </summary>
         /// <param name="counters">  to search within. </param>
         /// <param name="counterId"> for the active consensus position. </param>
-        /// <returns> the log position if found otherwise <seealso cref="Aeron.NULL_VALUE"/>. </returns>
+        /// <returns> the log position if found otherwise <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/>. </returns>
         public static long GetLogPosition(CountersReader counters, int counterId)
         {
             IDirectBuffer buffer = counters.MetaDataBuffer;
@@ -180,11 +180,11 @@ namespace Adaptive.Cluster.Service
 
 
         /// <summary>
-        /// Get the timestamp at the beginning of recovery. <seealso cref="Aeron.NULL_VALUE"/> if no snapshot for recovery.
+        /// Get the timestamp at the beginning of recovery. <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/> if no snapshot for recovery.
         /// </summary>
         /// <param name="counters">  to search within. </param>
         /// <param name="counterId"> for the active recovery counter. </param>
-        /// <returns> the timestamp if found otherwise <seealso cref="Aeron.NULL_VALUE"/>. </returns>
+        /// <returns> the timestamp if found otherwise <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/>. </returns>
         public static long GetTimestamp(CountersReader counters, int counterId)
         {
             IDirectBuffer buffer = counters.MetaDataBuffer;
@@ -231,7 +231,7 @@ namespace Adaptive.Cluster.Service
         /// <param name="counters">  to search within. </param>
         /// <param name="counterId"> for the active recovery counter. </param>
         /// <param name="serviceId"> for the snapshot required. </param>
-        /// <returns> the count of replay terms if found otherwise <seealso cref="Aeron.NULL_VALUE"/>. </returns>
+        /// <returns> the count of replay terms if found otherwise <see cref="Adaptive.Aeron.Aeron.NULL_VALUE"/>. </returns>
         public static long GetSnapshotRecordingId(CountersReader counters, int counterId, int serviceId)
         {
             IDirectBuffer buffer = counters.MetaDataBuffer;

--- a/src/Samples/Adaptive.Aeron.Samples.Common/RuntimeInformation.cs
+++ b/src/Samples/Adaptive.Aeron.Samples.Common/RuntimeInformation.cs
@@ -95,6 +95,7 @@ namespace Adaptive.Aeron.Samples.Common
                    && !new JitHelper().IsMsX64();
         }
 
+#pragma warning disable 162
         internal static string GetConfiguration()
         {
 #if DEBUG
@@ -102,6 +103,7 @@ namespace Adaptive.Aeron.Samples.Common
 #endif
             return "RELEASE";
         }
+#pragma warning restore 162
 
         // See http://aakinshin.net/en/blog/dotnet/jit-version-determining-in-runtime/
         private class JitHelper


### PR DESCRIPTION
- Use Fody.Virtuosity to make methods virtual for mocking (in Debug builds) instead of compiler directives
- Fix compiler warnings