### PR TITLE
Default `IoUtil.TmpDirName` to `Path.GetTempPath` on OSX

### DIFF
--- a/src/Adaptive.Agrona/IoUtil.cs
+++ b/src/Adaptive.Agrona/IoUtil.cs
@@ -17,6 +17,7 @@
 using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
 using Adaptive.Agrona.Util;
 
 namespace Adaptive.Agrona
@@ -196,13 +197,15 @@ namespace Adaptive.Agrona
             }
         }
 
+        private static readonly bool IsOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
         /// <summary>
         /// Return the system property for java.io.tmpdir ensuring a '/' is at the end.
         /// </summary>
         /// <returns> tmp directory for the runtime </returns>
         public static string TmpDirName()
         {
-            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            if (Environment.OSVersion.Platform == PlatformID.Unix && !IsOSX)
             {
                 return @"/dev/shm";
             }


### PR DESCRIPTION
On OSX the Aeron media driver uses the equivalent of C# `Path.GetTempPath()` by default. As the `Environment.OSVersion.Platform` returns `PlatformID.Unix` for OSX, the `IoUtil.TmpDirName` defaults to `/dev/shm` which doesn't match what the media driver chooses.

The fix uses `RuntimeInformation.IsOSPlatform` which only appeared in .NET Framework 4.7.1. Happy to have any other solution if this restriction doesn't work.
