### PR TITLE
Added another Wrap overload to UnsafeBuffer to support byte*

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
+++ b/src/Adaptive.Agrona/Concurrent/UnsafeBuffer.cs
@@ -257,7 +257,33 @@ namespace Adaptive.Agrona.Concurrent
             ByteBuffer = null;
             ByteArray = null;
         }
-        
+
+        public unsafe void Wrap(byte* pointer, int length)
+        {
+            FreeGcHandle();
+
+            _needToFreeGcHandle = false;
+
+            _pBuffer = pointer;
+            Capacity = length;
+
+            ByteBuffer = null;
+            ByteArray = null;
+        }
+
+        public unsafe void Wrap(byte* pointer, int offset, int length)
+        {
+            FreeGcHandle();
+
+            _needToFreeGcHandle = false;
+
+            _pBuffer = pointer + offset;
+            Capacity = length;
+
+            ByteBuffer = null;
+            ByteArray = null;
+        }
+
         public IntPtr BufferPointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
I came across a need to call Unsafe's buffer Wrap directly with a byte buffer. for example
Old case: (needed to create a needless instance of IntPtr)
```
var ub = new UnsafeBuffer();
var buffer = stackalloc byte[100];
ub.Wrap(new IntPtr(buffer), 100);
```

After pr:
```
var ub = new UnsafeBuffer();
var buffer = stackalloc byte[100];
ub.Wrap(buffer, 100);
```
