### PR TITLE
Missing null check for cluster connections

### DIFF
--- a/src/Adaptive.Agrona/CloseHelper.cs
+++ b/src/Adaptive.Agrona/CloseHelper.cs
@@ -63,7 +63,7 @@ namespace Adaptive.Agrona
         {
             try
             {
-                disposable.Dispose();
+                disposable?.Dispose();
             }
             catch (Exception ex)
             {

--- a/src/Adaptive.Cluster/Client/AeronCluster.cs
+++ b/src/Adaptive.Cluster/Client/AeronCluster.cs
@@ -1456,7 +1456,6 @@ namespace Adaptive.Cluster.Client
                 {
                     ErrorHandler errorHandler = ctx.ErrorHandler();
                     CloseHelper.Dispose(errorHandler, ingressPublication);
-                    CloseHelper.Dispose(errorHandler, ingressPublication);
 
                     foreach (var memberEndpoint in memberByIdMap.Values)
                     {


### PR DESCRIPTION
This adds a null check in `Dispose(ErrorHandler errorHandler, IDisposable disposable)`, similar to the other `CloseHelper.Dispose `methods.

Background:
When I try to connect to a cluster that is not running/responding, I do get the expected AeronTimeoutException from `AeronCluster.Connect()`. But additionally the ErrorHandler is called with a NullReferenceException.

The ErrorHandler is called from CloseHelper.Dispose:
```
at Adaptive.Agrona.CloseHelper.Dispose(ErrorHandler errorHandler, IDisposable disposable)
   at Adaptive.Cluster.Client.AeronCluster.AsyncConnect.Dispose()
   at Adaptive.Agrona.CloseHelper.QuietDispose(IDisposable disposable)
   at Adaptive.Cluster.Client.AeronCluster.Connect(Context ctx)
```

The NullReferenceException that is passed to the ErrorHandler has this StackTrace:
`   at Adaptive.Agrona.CloseHelper.Dispose(ErrorHandler errorHandler, IDisposable disposable)`
   
The issue is that `AsyncConnect.Dispose()` calls `CloseHelper.Dispose(errorHandler, ingressPublication)` where ingressPublication might still be null. Additionally `CloseHelper.Dispose(errorHandler, ingressPublication)` is called twice in `AsyncConnect.Dispose()`, which looks unintentional, so I removed this too.
