### PR TITLE
Add atomic IncrementAndGet to AtomicLong

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/AtomicLong.cs
+++ b/src/Adaptive.Agrona/Concurrent/AtomicLong.cs
@@ -49,5 +49,14 @@ namespace Adaptive.Agrona.Concurrent
         {
             Interlocked.Add(ref _long, add);
         }
+        
+        /// <summary>
+        /// Atomically increments the current value
+        /// </summary>
+        /// <returns> the udpated value.</returns>
+        public long IncrementAndGet()
+        {
+            return Interlocked.Increment(ref _long);
+        }
     }
 }


### PR DESCRIPTION
I have so code that depends on Agrona that requires IncrementAndGet on AtomicLong. Would be nice if it was there already. More closely matches the ported Java AtomicLong

Thanks