### PR TITLE
Reset SpinWaitIdleStrategy when work count is zero

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/SpinWaitIdleStrategy.cs
+++ b/src/Adaptive.Agrona/Concurrent/SpinWaitIdleStrategy.cs
@@ -29,10 +29,12 @@ namespace Adaptive.Agrona.Concurrent
         {
             if (workCount > 0)
             {
-                return;
+                Reset();
             }
-
-            _spinWait.SpinOnce();
+            else
+            {
+                _spinWait.SpinOnce();
+            }
         }
 
         public void Idle()


### PR DESCRIPTION
The agent duty cycle does not reset the idle strategy, so I believe idle strategies should reset themselves when the work count is zero. I noticed it done in [BackoffIdleStrategy](https://github.com/AdaptiveConsulting/Aeron.NET/blob/d79822e47225bb40372880ce43dcb04760539031/src/Adaptive.Agrona/Concurrent/BackoffIdleStrategy.cs#L69-L79) but not in SpinWaitIdleStrategy.