### PR TITLE
Added (presumably) missing "public" modifier to Image.Reject()

### DIFF
--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -847,7 +847,7 @@ namespace Adaptive.Aeron
         /// Reject this image.
         /// </summary>
         /// <param name="reason"> a String indicating the reason why this image is being rejected. </param>
-        void Reject(string reason)
+        public void Reject(string reason)
         {
             Subscription.RejectImage(CorrelationId, Position, reason);
         }


### PR DESCRIPTION
Public in all other APIs, seems to work fine, and even has public-looking doc... just was missing the actual "public" keyword, so couldn't actually be used.