### PR TITLE
"MaxPayloadLength" -> "maxPayloadLength" in AppendFragmentedMessage

### DIFF
--- a/src/Adaptive.Aeron/ExclusivePublication.cs
+++ b/src/Adaptive.Aeron/ExclusivePublication.cs
@@ -636,19 +636,19 @@ namespace Adaptive.Aeron
 		}
 
 		private int AppendFragmentedMessage(
-			UnsafeBuffer termBuffer, 
-			int tailCounterOffset, 
+			UnsafeBuffer termBuffer,
+			int tailCounterOffset,
 			IDirectBuffer bufferOne,
-			int offsetOne, 
-			int lengthOne, 
+			int offsetOne,
+			int lengthOne,
 			IDirectBuffer bufferTwo,
 			int offsetTwo,
-			int lengthTwo, 
+			int lengthTwo,
 			int maxPayloadLength,
 			ReservedValueSupplier reservedValueSupplier)
 		{
 			int length = lengthOne + lengthTwo;
-			int framedLength = ComputeFragmentedFrameLength(length, MaxPayloadLength);
+			int framedLength = ComputeFragmentedFrameLength(length, maxPayloadLength);
 			int termLength = termBuffer.Capacity;
 
 			int resultingOffset = _termOffset + framedLength;


### PR DESCRIPTION
Awfully subtle difference... and currently does not really matter or cause a bug, since everywhere that calls the version of `AppendFragmentedMessage` with a `maxPayloadLength` param just happens to pass in the `MaxPayloadLength` property value anyway.  But probably should be fixed nonetheless.