### PR TITLE
Added a constructor AgentTerminationException that takes another exception...

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/AgentTerminationException.cs
+++ b/src/Adaptive.Agrona/Concurrent/AgentTerminationException.cs
@@ -11,5 +11,9 @@ namespace Adaptive.Agrona.Concurrent
         public AgentTerminationException(string message) : base(message)
         {
         }
+
+        public AgentTerminationException(Exception innerException) : base(innerException?.ToString(), innerException)
+        {
+        }
     }
 }

--- a/src/Adaptive.Cluster/Service/ClusteredServiceAgent.cs
+++ b/src/Adaptive.Cluster/Service/ClusteredServiceAgent.cs
@@ -906,7 +906,7 @@ namespace Adaptive.Cluster.Service
             {
                 if (ex.ErrorCode == ArchiveException.STORAGE_SPACE)
                 {
-                    throw new AgentTerminationException();
+                    throw new AgentTerminationException(ex);
                 }
 
                 throw;


### PR DESCRIPTION
... so root causes of exceptions can be preserved, esp. in `AgentTerminationException`s.