### PR TITLE
Support invoker mode in AeronCluster

### DIFF
--- a/src/Adaptive.Cluster/Client/AeronCluster.cs
+++ b/src/Adaptive.Cluster/Client/AeronCluster.cs
@@ -2001,12 +2001,15 @@ namespace Adaptive.Cluster.Client
             {
                 int workDone = 0;
 
-                AgentInvoker conductorAgentInvoker = _aeron?.ConductorAgentInvoker;
-                if (null != conductorAgentInvoker)
+                if (null != _aeron)
                 {
-                    workDone += conductorAgentInvoker.Invoke();
+                    AgentInvoker conductorAgentInvoker = _aeron.ConductorAgentInvoker;
+                    if (null != conductorAgentInvoker)
+                    {
+                        workDone += conductorAgentInvoker.Invoke();
+                    }
                 }
-
+                
                 if (null != agentInvoker)
                 {
                     workDone += agentInvoker.Invoke();

--- a/src/Adaptive.Cluster/Client/AeronCluster.cs
+++ b/src/Adaptive.Cluster/Client/AeronCluster.cs
@@ -956,7 +956,7 @@ namespace Adaptive.Cluster.Client
             }
             else
             {
-                _publication = AddIngressPublication(_ctx, _ctx.IngressChannel(), _ctx.IngressStreamId());
+                _publication = AddNewLeaderIngressPublication(_ctx, _ctx.IngressChannel(), _ctx.IngressStreamId());
             }
 
             _fragmentAssembler.Clear();
@@ -1029,6 +1029,27 @@ namespace Adaptive.Cluster.Client
             }
         }
 
+        private Publication AddNewLeaderIngressPublication(Context ctx, string channel, int streamId)
+        {
+            long registrationId = AsyncAddIngressPublication(ctx, channel, streamId);
+            long deadlineNs = nanoClock.NanoTime() + ctx.MessageTimeoutNs();
+            do
+            {
+                Publication publication = GetIngressPublication(ctx, registrationId);
+                if (null != publication)
+                {
+                    return publication;
+                }
+                _idleStrategy.Idle(ctx.RunAgentInvokers());
+            }
+            while (nanoClock.NanoTime() < deadlineNs);
+
+            throw new AeronTimeoutException(
+                "failed to add new leader ingress publication (leaderMemberId=" + _leaderMemberId +
+                ", leadershipTermId=" + _leadershipTermId + ", channel=" + channel + ", streamId=" + streamId +
+                ") within " + ctx.MessageTimeoutNs() + "ns");
+        }
+
         internal static long AsyncAddIngressPublication(Context ctx, string channel, int streamId)
         {
             if (ctx.IsIngressExclusive())
@@ -1059,8 +1080,15 @@ namespace Adaptive.Cluster.Client
 
             var map = ParseIngressEndpoints(_ctx, ingressEndpoints);
             var newLeader = map.Get(leaderMemberId);
-            newLeader.CreateIngressPublication();
-            _publication = newLeader.publication;
+
+            ChannelUri channelUri = ChannelUri.Parse(_ctx.IngressChannel());
+            if (channelUri.IsUdp)
+            {
+                channelUri.Put(ENDPOINT_PARAM_NAME, newLeader.endpoint);
+            }
+
+            _publication = newLeader.publication =
+                AddNewLeaderIngressPublication(_ctx, channelUri.ToString(), _ctx.IngressStreamId());
             _endpointByIdMap = map;
         }
 
@@ -2359,6 +2387,11 @@ namespace Adaptive.Cluster.Client
                     {
                         foreach (MemberIngress member in memberByIdMap.Values)
                         {
+                            if (null == member.publication && NULL_VALUE != member.registrationId)
+                            {
+                                member.AsyncGetPublication();
+                            }
+
                             if (null != member.publication && member.publication.IsConnected)
                             {
                                 ingressPublication = member.publication;
@@ -2467,15 +2500,28 @@ namespace Adaptive.Cluster.Client
 
             private void UpdateMembers()
             {
-                CloseHelper.Dispose(ingressPublication);
-                CloseHelper.CloseAll(memberByIdMap.Values);
-                
                 leaderMemberId = egressPoller.LeaderMemberId();
+                MemberIngress oldLeader = memberByIdMap.Remove(leaderMemberId);
+
+                CloseHelper.Dispose(ingressPublication);
+                ingressPublication = null;
+                CloseHelper.CloseAll(memberByIdMap.Values);
+
                 memberByIdMap = ParseIngressEndpoints(ctx, egressPoller.Detail());
 
-                MemberIngress leader = memberByIdMap.Get(leaderMemberId);
-                leader.CreateIngressPublication();
-                ingressPublication = leader.publication;
+                MemberIngress newLeader = memberByIdMap.Get(leaderMemberId);
+                if (null != oldLeader &&
+                    null == oldLeader.publicationException &&
+                    newLeader.endpoint.Equals(oldLeader.endpoint))
+                {
+                    ingressPublication = newLeader.publication = oldLeader.publication;
+                    newLeader.registrationId = oldLeader.registrationId;
+                }
+                else
+                {
+                    CloseHelper.Dispose(oldLeader);
+                    newLeader.AsyncAddPublication();
+                }
 
                 State(AWAIT_PUBLICATION_CONNECTED);
             }
@@ -2526,6 +2572,35 @@ namespace Adaptive.Cluster.Client
             }
 
             publication = AddIngressPublication(ctx, channelUri.ToString(), ctx.IngressStreamId());
+        }
+
+        internal void AsyncAddPublication()
+        {
+            ChannelUri channelUri = ChannelUri.Parse(ctx.IngressChannel());
+            if (channelUri.IsUdp)
+            {
+                channelUri.Put(ENDPOINT_PARAM_NAME, endpoint);
+            }
+
+            registrationId = AsyncAddIngressPublication(ctx, channelUri.ToString(), ctx.IngressStreamId());
+            publication = null;
+        }
+
+        internal void AsyncGetPublication()
+        {
+            try
+            {
+                publication = GetIngressPublication(ctx, registrationId);
+                if (null != publication)
+                {
+                    registrationId = NULL_VALUE;
+                }
+            }
+            catch (RegistrationException ex)
+            {
+                publicationException = ex;
+                registrationId = NULL_VALUE;
+            }
         }
         
         public void Dispose()

--- a/src/Adaptive.Cluster/Client/AeronCluster.cs
+++ b/src/Adaptive.Cluster/Client/AeronCluster.cs
@@ -1969,6 +1969,24 @@ namespace Adaptive.Cluster.Client
                 return agentInvoker;
             }
 
+            internal int RunAgentInvokers()
+            {
+                int workDone = 0;
+
+                AgentInvoker conductorAgentInvoker = _aeron?.ConductorAgentInvoker;
+                if (null != conductorAgentInvoker)
+                {
+                    workDone += conductorAgentInvoker.Invoke();
+                }
+
+                if (null != agentInvoker)
+                {
+                    workDone += agentInvoker.Invoke();
+                }
+
+                return workDone;
+            }
+
             /// <summary>
             /// Close the context and free applicable resources.
             /// <para>
@@ -2168,6 +2186,7 @@ namespace Adaptive.Cluster.Client
             public AeronCluster Poll()
             {
                 CheckDeadline();
+                ctx.RunAgentInvokers();
 
                 switch (state)
                 {


### PR DESCRIPTION
Various changes to allow invoker mode to not just hang waiting forever or deadlock in AeronCluster.

- Added Context.RunAgentInvokers and call from AsyncConnect.Poll
- Changed AeronCluster.OnNewLeader and UpdateMemberEndpoints to use new AsyncAddIngressPublication instead of AddIngressPublication
- Changed UpdateMembers to match current Java API code