### PR TITLE
Fix wrong decoder used for leadershipTermId in EgressAdapter NewLeader path

### DIFF
--- a/src/Adaptive.Cluster/Client/EgressAdapter.cs
+++ b/src/Adaptive.Cluster/Client/EgressAdapter.cs
@@ -158,7 +158,7 @@ namespace Adaptive.Cluster.Client
                     {
                         _listener.OnNewLeader(
                             sessionId,
-                            _sessionEventDecoder.LeadershipTermId(),
+                            _newLeaderEventDecoder.LeadershipTermId(),
                             _newLeaderEventDecoder.LeaderMemberId(),
                             _newLeaderEventDecoder.IngressEndpoints());
                     }


### PR DESCRIPTION
Not sure what sort of havoc this might've caused, if any, but it sure didn't seem right...