### PR TITLE
Preserve underlying stack trace on AeronArchive.AsyncConnect constructor failure

### DIFF
--- a/src/Adaptive.Archiver/AeronArchive.cs
+++ b/src/Adaptive.Archiver/AeronArchive.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using Adaptive.Aeron;
 using Adaptive.Aeron.Exceptions;
@@ -3499,7 +3500,7 @@ namespace Adaptive.Archiver
                 catch (Exception ex)
                 {
                     Dispose();
-                    throw ex;
+                    ExceptionDispatchInfo.Capture(ex).Throw();
                 }
             }
 


### PR DESCRIPTION
Nicer for debugging; otherwise all we get is "it failed in the constructor!" for no particular reason.