### PR TITLE
Preserve inner exception in ClientConductor.Service for better debugging

### DIFF
--- a/src/Adaptive.Aeron/ClientConductor.cs
+++ b/src/Adaptive.Aeron/ClientConductor.cs
@@ -1759,7 +1759,7 @@ namespace Adaptive.Aeron
 
                     if (!IsClientApiCall(correlationId))
                     {
-                        throw new AeronException("Driver events adapter is invalid");
+                        throw new AeronException("Driver events adapter is invalid", ex);
                     }
                 }
 


### PR DESCRIPTION
Just nice to have, & matches Java behavior.