### PR TITLE
Fix ValidateCounterId so an ID exactly equal to MaxCounterId also fails

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
@@ -447,7 +447,12 @@ namespace Adaptive.Agrona.Concurrent.Status
 
         private void ValidateCounterId(int counterId)
         {
-            if (counterId < 0 || counterId > MaxCounterId)
+            // .NET's MaxCounterId is one-past-max (capacity / COUNTER_LENGTH), used as the
+            // upper bound in `for (i = 0; i < MaxCounterId; i++)` iteration loops throughout
+            // the codebase. So a counterId equal to MaxCounterId is out of bounds — it would
+            // produce CounterOffset(counterId) == capacity and a buffer-overrun read.
+            // Java's maxCounterId is one less (inclusive max) and uses `> maxCounterId` here.
+            if (counterId < 0 || counterId >= MaxCounterId)
             {
                 throw new System.ArgumentException("Counter id " + counterId + " out of range: maxCounterId=" + MaxCounterId);
             }


### PR DESCRIPTION
**NOTE:** This PR being created as a draft for discussion.

Java's maxCounterId is set to:

```
this.maxCounterId = (valuesBuffer.capacity() / COUNTER_LENGTH) - 1;
```

whereas .NET's is:

```
MaxCounterId = valuesBuffer.Capacity / COUNTER_LENGTH;
```

The _better_ fix, IMO, is to change .NET to match Java, so "max counter ID" really is the max counter ID, not one higher than the max ID.

However, it's a public value, and users might already have code that uses it, so that would be a potentially breaking change.

The change in this PR is the simpler, non-breaking thing we could do.  Which do we prefer?