### PR TITLE
Added some extra sanity checks in CountersManager.Free

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/Status/CountersManager.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersManager.cs
@@ -314,9 +314,16 @@ namespace Adaptive.Agrona.Concurrent.Status
         /// <param name="counterId"> the counter to freed </param>
         public void Free(int counterId)
         {
+            ValidateCounterId(counterId);
             int recordOffset = MetaDataOffset(counterId);
 
+            if (RECORD_ALLOCATED != MetaDataBuffer.GetIntVolatile(recordOffset))
+            {
+                throw new System.InvalidOperationException("counter not allocated: id=" + counterId);
+            }
+
             MetaDataBuffer.PutLong(recordOffset + FREE_FOR_REUSE_DEADLINE_OFFSET, _epochClock.Time() + _freeToReuseTimeoutMs);
+            MetaDataBuffer.SetMemory(recordOffset + KEY_OFFSET, MAX_KEY_LENGTH, 0);
             MetaDataBuffer.PutIntOrdered(recordOffset, RECORD_RECLAIMED);
             _freeList.Add(counterId);
         }
@@ -343,7 +350,7 @@ namespace Adaptive.Agrona.Concurrent.Status
 
                 if (nowMs >= deadlineMs)
                 {
-                    _freeList.Remove(i);
+                    _freeList.RemoveAt(i);
                     ValuesBuffer.PutLongOrdered(CounterOffset(counterId), 0L);
 
                     return counterId;

--- a/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
+++ b/src/Adaptive.Agrona/Concurrent/Status/CountersReader.cs
@@ -445,7 +445,7 @@ namespace Adaptive.Agrona.Concurrent.Status
             return LabelValue(MetaDataOffset(counterId));
         }
 
-        private void ValidateCounterId(int counterId)
+        protected void ValidateCounterId(int counterId)
         {
             if (counterId < 0 || counterId > MaxCounterId)
             {


### PR DESCRIPTION
Matches the Java code now and prevents corruption if a bogus counter ID is passed in.

Also fixed a use of `Remove()` that _probably_ should have been `RemoveAt()`.