### PR TITLE
Added a missing "else" in AgentRunner.close() to match Java

### DIFF
--- a/src/Adaptive.Agrona/Concurrent/AgentRunner.cs
+++ b/src/Adaptive.Agrona/Concurrent/AgentRunner.cs
@@ -191,7 +191,7 @@ namespace Adaptive.Agrona.Concurrent
                     _errorHandler.OnError(ex);
                 }
             }
-            if (TOMBSTONE != thread)
+            else if (TOMBSTONE != thread)
             {
                 while (true)
                 {


### PR DESCRIPTION
...and avoid an NPE if an AgentRunner was created, never started, and then closed.