### PR TITLE
chore: bump dependencies

### DIFF
--- a/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
+++ b/src/Adaptive.Aeron.Tests/Adaptive.Aeron.Tests.csproj
@@ -6,9 +6,9 @@
 
     <ItemGroup>
         <PackageReference Include="FakeItEasy" Version="8.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NUnit" Version="3.14.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Adaptive.Aeron/Adaptive.Aeron.csproj
+++ b/src/Adaptive.Aeron/Adaptive.Aeron.csproj
@@ -17,7 +17,7 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
     <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <PackageReference Include="Fody" Version="6.9.2">
+        <PackageReference Include="Fody" Version="6.9.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.csproj
+++ b/src/Adaptive.Agrona.Tests/Adaptive.Agrona.Tests.csproj
@@ -6,9 +6,9 @@
 
     <ItemGroup>
         <PackageReference Include="FakeItEasy" Version="8.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NUnit" Version="3.14.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Adaptive.Agrona/Adaptive.Agrona.csproj
+++ b/src/Adaptive.Agrona/Adaptive.Agrona.csproj
@@ -18,7 +18,7 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
     <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <PackageReference Include="Fody" Version="6.9.2">
+        <PackageReference Include="Fody" Version="6.9.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
@@ -27,7 +27,7 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="FodyWeavers.xsd" />


### PR DESCRIPTION
- Fody 6.9.2 -> 6.9.3 (Adaptive.Aeron, Adaptive.Agrona)
- System.Runtime.CompilerServices.Unsafe 6.1.0 -> 6.1.2 (Adaptive.Agrona)
- Microsoft.NET.Test.Sdk 17.13.0 -> 18.5.1 (Adaptive.Aeron.Tests, Adaptive.Agrona.Tests)
- NUnit3TestAdapter 5.0.0 -> 6.2.0 (Adaptive.Aeron.Tests, Adaptive.Agrona.Tests)

NUnit and FakeItEasy also have newer versions available but require .NET 10, so leaving unchanged.