### PR TITLE
Port API and docs changes

### DIFF
--- a/src/Adaptive.Aeron/Image.cs
+++ b/src/Adaptive.Aeron/Image.cs
@@ -176,6 +176,7 @@ namespace Adaptive.Aeron
         /// <summary>
         /// The position this <seealso cref="Image"/> has been consumed to by the subscriber.
         /// </summary>
+        /// <remarks> The Position setter is deprecated and will be removed in 1.53.0. </remarks>
         /// <returns> the position this <seealso cref="Image"/> has been consumed to by the subscriber. </returns>
         public long Position
         {
@@ -730,6 +731,7 @@ namespace Adaptive.Aeron
         /// <returns> the resulting position after the scan terminates which is a complete message. </returns>
         /// <seealso cref="ControlledFragmentAssembler"/>
         /// <seealso cref="ImageControlledFragmentAssembler"/>
+        [Obsolete("Will be removed in 1.53.0.")]
         public long ControlledPeek(long initialPosition, IControlledFragmentHandler handler, long limitPosition)
         {
             if (_isClosed)
@@ -809,6 +811,7 @@ namespace Adaptive.Aeron
             return resultingPosition;
         }
 
+        [Obsolete("Will be removed in 1.53.0.")]
         public long ControlledPeek(long initialPosition, ControlledFragmentHandler handler, long limitPosition)
         {
             var fragmentHandler = HandlerHelper.ToControlledFragmentHandler(handler);

--- a/src/Adaptive.Archiver/AeronArchive.cs
+++ b/src/Adaptive.Archiver/AeronArchive.cs
@@ -1705,6 +1705,8 @@ namespace Adaptive.Archiver
         /// position must be on a fragment boundary. Truncating a recording to the start position effectively deletes
         /// the recording.
         ///
+        /// Truncating a recording will stop any concurrent replays of that recording.
+        ///
         /// </summary>
         /// <param name="recordingId"> of the stopped recording to be truncated. </param>
         /// <param name="position">    to which the recording will be truncated. </param>

--- a/src/Adaptive.Archiver/ArchiveProxy.cs
+++ b/src/Adaptive.Archiver/ArchiveProxy.cs
@@ -742,6 +742,8 @@ namespace Adaptive.Archiver
         /// position must be on a fragment boundary. Truncating a recording to the start position effectively deletes
         /// the recording.
         ///
+        /// Truncating a recording will stop any concurrent replays of that recording.
+        ///
         /// </summary>
         /// <param name="recordingId">      of the stopped recording to be truncated. </param>
         /// <param name="position">         to which the recording will be truncated. </param>


### PR DESCRIPTION
Ports over the deprecation notice for `ControlledPeek` and Aeron archive doc changes. 

As Aeron.NET is on C# 7.3, the `Image.Position` setter deprecation is a doc note, not an accessor-specific [Obsolete] as that would require C# 8.