### PR TITLE
Port changes to ControlProtocolException

### DIFF
--- a/src/Adaptive.Aeron.Tests/Exceptions/ControlProtocolExceptionTest.cs
+++ b/src/Adaptive.Aeron.Tests/Exceptions/ControlProtocolExceptionTest.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 - 2026 Adaptive Financial Consulting Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Adaptive.Aeron.Exceptions;
+using NUnit.Framework;
+
+namespace Adaptive.Aeron.Tests.Exceptions
+{
+    public class ControlProtocolExceptionTest
+    {
+        private static readonly Exception RootCause = new InvalidOperationException("root cause");
+
+        public static IEnumerable<TestCaseData> CategoryCases()
+        {
+            yield return new TestCaseData(
+                    new ControlProtocolException(ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE, "msg"),
+                    Category.WARN)
+                .SetName("MessageCtorMapsResourceTemporarilyUnavailableToWarn");
+            yield return new TestCaseData(
+                    new ControlProtocolException(ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE, RootCause),
+                    Category.WARN)
+                .SetName("RootCauseCtorMapsResourceTemporarilyUnavailableToWarn");
+            yield return new TestCaseData(
+                    new ControlProtocolException(ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE, "msg", RootCause),
+                    Category.WARN)
+                .SetName("MessageAndRootCauseCtorMapsResourceTemporarilyUnavailableToWarn");
+
+            yield return new TestCaseData(
+                    new ControlProtocolException(ErrorCode.MALFORMED_COMMAND, "msg"),
+                    Category.ERROR)
+                .SetName("MessageCtorMapsMalformedCommandToError");
+            yield return new TestCaseData(
+                    new ControlProtocolException(ErrorCode.MALFORMED_COMMAND, RootCause),
+                    Category.ERROR)
+                .SetName("RootCauseCtorMapsMalformedCommandToError");
+            yield return new TestCaseData(
+                    new ControlProtocolException(ErrorCode.MALFORMED_COMMAND, "msg", RootCause),
+                    Category.ERROR)
+                .SetName("MessageAndRootCauseCtorMapsMalformedCommandToError");
+        }
+
+        [TestCaseSource(nameof(CategoryCases))]
+        public void ShouldDeriveCategoryFromErrorCode(ControlProtocolException exception, Category expected)
+        {
+            Assert.AreEqual(expected, exception.Category);
+        }
+    }
+}

--- a/src/Adaptive.Aeron/Exceptions/AeronException.cs
+++ b/src/Adaptive.Aeron/Exceptions/AeronException.cs
@@ -52,6 +52,11 @@ namespace Adaptive.Aeron.Exceptions
             Category = Category.ERROR;
         }
 
+        public AeronException(Exception cause, Category category) : base(cause?.ToString(), cause)
+        {
+            Category = category;
+        }
+
         protected AeronException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             Category = Category.ERROR;

--- a/src/Adaptive.Aeron/Exceptions/ControlProtocolException.cs
+++ b/src/Adaptive.Aeron/Exceptions/ControlProtocolException.cs
@@ -28,7 +28,7 @@ namespace Adaptive.Aeron.Exceptions
         /// <param name="code"> for the type of error. </param>
         /// <param name="msg">  providing more detail. </param>
         public ControlProtocolException(ErrorCode code, string msg)
-            : base(msg)
+            : base(msg, ErrorToCategory(code))
         {
             _code = code;
         }
@@ -39,7 +39,7 @@ namespace Adaptive.Aeron.Exceptions
         /// <param name="code">      for the type of error. </param>
         /// <param name="rootCause"> of the error. </param>
         public ControlProtocolException(ErrorCode code, Exception rootCause)
-            : base(rootCause)
+            : base(rootCause, ErrorToCategory(code))
         {
             _code = code;
         }
@@ -51,7 +51,7 @@ namespace Adaptive.Aeron.Exceptions
         /// <param name="msg">       providing more detail. </param>
         /// <param name="rootCause"> of the error. </param>
         public ControlProtocolException(ErrorCode code, string msg, Exception rootCause)
-            : base(msg, rootCause)
+            : base(msg, rootCause, ErrorToCategory(code))
         {
             _code = code;
         }
@@ -64,6 +64,11 @@ namespace Adaptive.Aeron.Exceptions
         public ErrorCode ErrorCode()
         {
             return _code;
+        }
+
+        internal static Category ErrorToCategory(ErrorCode code)
+        {
+            return Adaptive.Aeron.ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE == code ? Category.WARN : Category.ERROR;
         }
     }
 }

--- a/src/Adaptive.Aeron/PublicAPI.Unshipped.txt
+++ b/src/Adaptive.Aeron/PublicAPI.Unshipped.txt
@@ -105,3 +105,4 @@ Adaptive.Aeron.Security.SimpleAuthorisationService.Builder.AddGeneralRule(int pr
 Adaptive.Aeron.Security.SimpleAuthorisationService.Builder.AddGeneralRule(int protocolId, int actionId, bool isAllowed) -> Adaptive.Aeron.Security.SimpleAuthorisationService.Builder
 Adaptive.Aeron.Security.SimpleAuthorisationService.Builder.AddGeneralRule(int protocolId, bool isAllowed) -> Adaptive.Aeron.Security.SimpleAuthorisationService.Builder
 Adaptive.Aeron.Security.SimpleAuthorisationService.Builder.NewInstance() -> Adaptive.Aeron.Security.SimpleAuthorisationService
+Adaptive.Aeron.Exceptions.AeronException.AeronException(System.Exception cause, Adaptive.Aeron.Exceptions.Category category) -> void


### PR DESCRIPTION
This ports Aeron 1.52.0 changes to ControlProtocolException to Aeron.NET as a parity-only change.